### PR TITLE
Fix Conflicts With MSU Randomizer

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.7.3</Version>
+    <Version>9.7.4</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Speech.Recognition;
 using System.Timers;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,7 @@ public class MsuModule : TrackerModule, IDisposable
     private int _currentTrackNumber;
     private readonly HashSet<int> _validTrackNumbers;
     private Track? _currentTrack;
+    private bool _isSetup;
 
     /// <summary>
     /// Constructor
@@ -65,6 +67,11 @@ public class MsuModule : TrackerModule, IDisposable
         if (!File.Exists(tracker.RomPath))
         {
             throw new InvalidOperationException("No tracker rom file found");
+        }
+
+        if (string.IsNullOrEmpty(tracker.Rom?.MsuPaths))
+        {
+            return;
         }
 
         var romFileInfo = new FileInfo(tracker.RomPath);
@@ -101,6 +108,7 @@ public class MsuModule : TrackerModule, IDisposable
         }
 
         tracker.TrackNumberUpdated += TrackerOnTrackNumberUpdated;
+        _isSetup = true;
 
     }
 
@@ -378,6 +386,11 @@ public class MsuModule : TrackerModule, IDisposable
     [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public override void AddCommands()
     {
+        if (!_isSetup)
+        {
+            return;
+        }
+
         AddCommand("location song", GetLocationSongRules(), (result) =>
         {
             if (_currentMsu == null)

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -36,8 +36,6 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.CasPatches.RandomizedBottles = false;
 
             var seedData = randomizer.GenerateSeed(config, seed, default);
-            var locations = string.Join("\r\n", seedData.WorldGenerationData.LocalWorld.World.Locations.OrderBy(x => x.Id)
-                .Select(x => $"{x.Id} {x.Item.Type}"));
             var worldHash = GetHashForWorld(seedData.WorldGenerationData.LocalWorld.World);
 
             worldHash.Should().Be(expectedHash);

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 
 using FluentAssertions;
@@ -28,12 +29,6 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         [InlineData("test", -787405869)] // Smz3Randomizer v5.0
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
-            // Apparently RNG in Linux is different than on Windows...
-            if (OperatingSystem.IsLinux())
-            {
-                expectedHash = 1752413809;
-            }
-
             var filler = new StandardFiller(GetLogger<StandardFiller>());
             var randomizer = GetRandomizer();
             var config = new Config();
@@ -41,6 +36,8 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.CasPatches.RandomizedBottles = false;
 
             var seedData = randomizer.GenerateSeed(config, seed, default);
+            var locations = string.Join("\r\n", seedData.WorldGenerationData.LocalWorld.World.Locations.OrderBy(x => x.Id)
+                .Select(x => $"{x.Id} {x.Item.Type}"));
             var worldHash = GetHashForWorld(seedData.WorldGenerationData.LocalWorld.World);
 
             worldHash.Should().Be(expectedHash);
@@ -56,7 +53,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
                 stringBuilder.Append(location.Id);
                 stringBuilder.Append(':');
                 stringBuilder.Append((int)location.Item.Type);
-                stringBuilder.AppendLine();
+                stringBuilder.Append("\r\n");
             }
             var serializedWorld = stringBuilder.ToString();
             return NonCryptographicHash.Fnv1a(serializedWorld);


### PR DESCRIPTION
Basically, if someone used the MSU Randomizer to generate a MSU before opening tracker, she would read the YML on launch even if the person specified no MSU. I'm removing this functionality entirely of reading the MSU if no MSU is specified in SMZ3.

This also fixes the unit test differences between Windows and other operating systems.