### PR TITLE
#452: Added failsafe for blank sprite names

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.7.4</Version>
+    <Version>9.7.5</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.SMZ3/Generation/SpritePatcherService.cs
+++ b/src/Randomizer.SMZ3/Generation/SpritePatcherService.cs
@@ -22,11 +22,11 @@ public class SpritePatcherService
     {
         var linkSprite = _spriteService.GetSprite(SpriteType.Link);
         ApplyRdcSpriteTo(linkSprite, bytes);
-        linkSpriteName = linkSprite.Name;
+        linkSpriteName = string.IsNullOrEmpty(linkSprite.Name) ? "Link" : linkSprite.Name;
 
         var samusSprite = _spriteService.GetSprite(SpriteType.Samus);
         ApplyRdcSpriteTo(samusSprite, bytes);
-        samusSpriteName = samusSprite.Name;
+        samusSpriteName = string.IsNullOrEmpty(samusSprite.Name) ? "Samus" : samusSprite.Name;
 
         var shipSprite = _spriteService.GetSprite(SpriteType.Ship);
         ApplyShipSpriteTo(shipSprite, bytes);


### PR DESCRIPTION
This handles cases where weirdos like me who always leave the default sprites selected were getting blank names in hints after closing and restarting Tracker. This may have something to do with the default sprites not having their paths saved in `randomizer-options.yml`?

Closes #452