### PR TITLE
Fix progression item location option

### DIFF
--- a/src/Randomizer.SMZ3/Generation/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/StandardFiller.cs
@@ -157,7 +157,10 @@ namespace Randomizer.SMZ3.Generation
                         // Some locations (AKA Shaktool) get pretty tough to tell if an item is needed there, so a workaround is to
                         // grab an item from the opposite game to minimize chances of situations where an item required to access a
                         // location is picked to go there
-                        var item = progressionItems.FirstOrDefault(x => x.Type.IsInCategory(ItemCategory.Metroid) && location.Region is Z3Region || x.Type.IsInCategory(ItemCategory.Zelda) && location.Region is SMRegion);
+                        var item = progressionItems.Where(x =>
+                            ((x.Type.IsInCategory(ItemCategory.Metroid) && location.Region is Z3Region) ||
+                            (x.Type.IsInCategory(ItemCategory.Zelda) && location.Region is SMRegion)) &&
+                            !x.Type.IsInAnyCategory(ItemCategory.Junk, ItemCategory.Scam)).Random(Random);
 
                         if (item != null)
                         {


### PR DESCRIPTION
Fixes #486

I don't think this ever actually worked fully. lol Two main issues. The progression item pool was not randomized, so it always picked the first item in the list. Secondly, I got rid of junk progression items (such as the 300 rupees) to increase the likelihood of a genuine required progression item is there. It's still not 100% required, though.