### PR TITLE
Fix MSU resume cancel

### DIFF
--- a/src/Randomizer.CrossPlatform/Randomizer.CrossPlatform.csproj
+++ b/src/Randomizer.CrossPlatform/Randomizer.CrossPlatform.csproj
@@ -17,9 +17,9 @@
 
     <ItemGroup>
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="MattEqualsCoder.AvaloniaControls" Version="0.9.15" />
-        <PackageReference Include="MattEqualsCoder.DynamicForms.Avalonia" Version="0.0.3-rc.3" />
-        <PackageReference Include="MattEqualsCoder.MSURandomizer.Avalonia" Version="2.1.0-rc.4" />
+        <PackageReference Include="MattEqualsCoder.AvaloniaControls" Version="0.9.16" />
+        <PackageReference Include="MattEqualsCoder.DynamicForms.Avalonia" Version="0.0.3-rc.4" />
+        <PackageReference Include="MattEqualsCoder.MSURandomizer.Avalonia" Version="2.1.0-rc.5" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />

--- a/src/Randomizer.CrossPlatform/Services/SharedCrossplatformService.cs
+++ b/src/Randomizer.CrossPlatform/Services/SharedCrossplatformService.cs
@@ -174,7 +174,7 @@ public class SharedCrossplatformService(
                 scope.Dispose();
             };
             s_trackerWindow.Rom = rom;
-            s_trackerWindow.Show(ParentWindow);
+            s_trackerWindow.Show();
             return s_trackerWindow;
         }
         catch (YamlDotNet.Core.SemanticErrorException ex)

--- a/src/Randomizer.CrossPlatform/Services/TrackerWindowService.cs
+++ b/src/Randomizer.CrossPlatform/Services/TrackerWindowService.cs
@@ -223,7 +223,7 @@ public class TrackerWindowService(
         }
 
         _trackerMapWindow = serviceProvider.GetRequiredService<TrackerMapWindow>();
-        _trackerMapWindow.Show(_window.Owner as Window ?? _window);
+        _trackerMapWindow.Show(_window);
         _trackerMapWindow.Closed += (_, _) => _trackerMapWindow = null;
     }
 
@@ -235,7 +235,7 @@ public class TrackerWindowService(
         }
 
         _trackerLocationsWindow = serviceProvider.GetRequiredService<TrackerLocationsWindow>();
-        _trackerLocationsWindow.Show(_window.Owner as Window ?? _window);
+        _trackerLocationsWindow.Show(_window);
         _trackerLocationsWindow.OutOfLogicChanged += TrackerLocationsWindowOnOutOfLogicChanged;
         _trackerLocationsWindow.Closed += (_, _) =>
         {
@@ -474,7 +474,7 @@ public class TrackerWindowService(
         }
 
         _trackerHelpWindow = serviceProvider.GetRequiredService<TrackerHelpWindow>();
-        _trackerHelpWindow.Show(_window.Owner as Window ?? _window);
+        _trackerHelpWindow.Show(_window);
         _trackerHelpWindow.Closed += (_, _) => _trackerHelpWindow = null;
     }
 
@@ -725,7 +725,7 @@ public class TrackerWindowService(
             Buttons = buttons
         });
 
-        await window.ShowDialog(_window.Owner as Window ?? _window);
+        await window.ShowDialog(_window);
 
         return window.DialogResult;
     }

--- a/src/Randomizer.CrossPlatform/Views/CurrentTrackWindow.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/CurrentTrackWindow.axaml.cs
@@ -36,6 +36,6 @@ public partial class CurrentTrackWindow : RestorableWindow
 
     protected override string RestoreFilePath => Path.Combine(Directories.AppDataFolder, "Windows", "msu-monitor.json");
     protected override int DefaultWidth => 600;
-    protected override int DefualtHeight => 400;
+    protected override int DefaultHeight => 400;
 }
 

--- a/src/Randomizer.CrossPlatform/Views/MainWindow.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/MainWindow.axaml.cs
@@ -49,7 +49,7 @@ public partial class MainWindow : RestorableWindow
 
     protected override string RestoreFilePath => Path.Combine(Directories.AppDataFolder, "Windows", "main-window.json");
     protected override int DefaultWidth => 800;
-    protected override int DefualtHeight => 600;
+    protected override int DefaultHeight => 600;
 
     private void CloseUpdateButton_OnClick(object? sender, RoutedEventArgs e)
     {

--- a/src/Randomizer.CrossPlatform/Views/MultiplayerStatusWindow.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/MultiplayerStatusWindow.axaml.cs
@@ -38,7 +38,7 @@ public partial class MultiplayerStatusWindow : RestorableWindow
 
     protected override string RestoreFilePath => Path.Combine(Directories.AppDataFolder, "Windows", "multiplayer-status-window.json");
     protected override int DefaultWidth => 500;
-    protected override int DefualtHeight => 250;
+    protected override int DefaultHeight => 250;
 
     private async void CopyUrlButton_OnClick(object? sender, RoutedEventArgs e)
     {

--- a/src/Randomizer.CrossPlatform/Views/TrackerLocationsWindow.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/TrackerLocationsWindow.axaml.cs
@@ -35,7 +35,7 @@ public partial class TrackerLocationsWindow : RestorableWindow
 
     protected override string RestoreFilePath => Path.Combine(Directories.AppDataFolder, "Windows", "tracker-locations-window.json");
     protected override int DefaultWidth => 450;
-    protected override int DefualtHeight => 600;
+    protected override int DefaultHeight => 600;
 
     public event EventHandler<OutOfLogicChangedEventArgs>? OutOfLogicChanged;
 

--- a/src/Randomizer.CrossPlatform/Views/TrackerMapWindow.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/TrackerMapWindow.axaml.cs
@@ -50,7 +50,7 @@ public partial class TrackerMapWindow : RestorableWindow
 
     protected override string RestoreFilePath => Path.Combine(Directories.AppDataFolder, "Windows", "tracker-map-window.json");
     protected override int DefaultWidth => 1024;
-    protected override int DefualtHeight => 768;
+    protected override int DefaultHeight => 768;
 
     private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {

--- a/src/Randomizer.CrossPlatform/Views/TrackerWindow.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/TrackerWindow.axaml.cs
@@ -74,7 +74,7 @@ public partial class TrackerWindow : RestorableWindow
         }
 
         _currentTrackWindow = new CurrentTrackWindow();
-        _currentTrackWindow.Show(Owner as Window ?? this);
+        _currentTrackWindow.Show(this);
         _currentTrackWindow.Closed += (_, _) => _currentTrackWindow = null;
     }
 
@@ -125,7 +125,7 @@ public partial class TrackerWindow : RestorableWindow
 
     protected override string RestoreFilePath => Path.Combine(Directories.AppDataFolder, "Windows", "tracker-window.json");
     protected override int DefaultWidth => 350;
-    protected override int DefualtHeight => 300;
+    protected override int DefaultHeight => 300;
 
     private void Control_OnLoaded(object? sender, RoutedEventArgs e)
     {
@@ -148,6 +148,8 @@ public partial class TrackerWindow : RestorableWindow
                 _service?.OpenTrackerMapWindow();
             }, DispatcherPriority.Background);
         });
+
+        MessageWindow.GlobalParentWindow?.Hide();
     }
 
     private async void LoadSavedStateMenuItem_OnClick(object? sender, RoutedEventArgs e)
@@ -197,6 +199,8 @@ public partial class TrackerWindow : RestorableWindow
         }
 
         _currentTrackWindow?.Close(true);
+
+        MessageWindow.GlobalParentWindow?.Show();
     }
 
     private void TimeTextBlock_OnPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
@@ -22,6 +22,7 @@ public class MsuModule : TrackerModule, IDisposable
     private Msu? _currentMsu;
     private readonly MsuConfig _msuConfig;
     private readonly IMsuMonitorService _msuMonitorService;
+    private readonly IGameService _gameService;
     private readonly string _msuKey = "MsuKey";
     private int _currentTrackNumber;
     private readonly HashSet<int> _validTrackNumbers;
@@ -40,6 +41,7 @@ public class MsuModule : TrackerModule, IDisposable
     /// <param name="msuTypeService"></param>
     /// <param name="msuUserOptionsService"></param>
     /// <param name="msuConfig"></param>
+    /// <param name="gameService"></param>
     public MsuModule(
         TrackerBase tracker,
         IItemService itemService,
@@ -49,9 +51,11 @@ public class MsuModule : TrackerModule, IDisposable
         IMsuMonitorService msuMonitorService,
         IMsuTypeService msuTypeService,
         IMsuUserOptionsService msuUserOptionsService,
-        MsuConfig msuConfig)
+        MsuConfig msuConfig,
+        IGameService gameService)
         : base(tracker, itemService, worldService, logger)
     {
+        _gameService = gameService;
         _msuMonitorService = msuMonitorService;
         var msuType = msuTypeService.GetSMZ3MsuType();
         _msuConfig = msuConfig;
@@ -114,9 +118,15 @@ public class MsuModule : TrackerModule, IDisposable
         }
 
         msuMonitorService.MsuTrackChanged += MsuMonitorServiceOnMsuTrackChanged;
+        msuMonitorService.MsuShuffled += MsuMonitorServiceOnMsuShuffled;
 
         _isSetup = true;
 
+    }
+
+    private void MsuMonitorServiceOnMsuShuffled(object? sender, EventArgs e)
+    {
+        _gameService.TryCancelMsuResume();
     }
 
     private void MsuMonitorServiceOnMsuTrackChanged(object sender, MsuTrackChangedEventArgs e)


### PR DESCRIPTION
Fixes #509

Also fixes the typo Vivelin brought up, and this now hides the seed window when tracker is pulled up. Avalonia was having some weird behavior where trying to close the seed window would close tracker? Plus, I figured this avoids the confusion of people changing the settings but tracker not taking the changes unless you restart tracker.