### PR TITLE
Require bombs to leave Hi Jump Lobby Missile

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.8.0-rc.3</Version>
+    <Version>9.8.0-rc4</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
@@ -132,7 +132,7 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
                     new Location(this, LocationId.UpperNorfairHiJumpEnergyTankLeft, 0x8F8BE6, LocationType.Visible,
                         name: "Missile (Hi-Jump Boots)",
                         vanillaItem: ItemType.Missile,
-                        access: items => Logic.CanOpenRedDoors(items) && items.Morph,
+                        access: items => Logic.CanOpenRedDoors(items) && Logic.CanPassBombPassages(items),
                         memoryAddress: 0x6,
                         memoryFlag: 0x80,
                         metadata: metadata,

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -37,7 +37,7 @@ namespace Randomizer.SMZ3.Generation
 
         public static string Name => "Super Metroid & A Link to the Past Cas’ Randomizer";
 
-        public static Version Version => new(5, 0);
+        public static Version Version => new(5, 1);
 
         protected IFiller Filler { get; }
 

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LocationLogicTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LocationLogicTests.cs
@@ -9,6 +9,7 @@ using Randomizer.Data.Logic;
 using Randomizer.Data.Options;
 using Randomizer.Data.WorldData;
 using Randomizer.Shared;
+using Randomizer.Shared.Enums;
 
 using Xunit;
 
@@ -83,6 +84,14 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
             var missingItems = Logic.GetMissingRequiredItems(World.FindLocation(LocationId.CrateriaBombTorizo), emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.Morph, ItemType.Super, ItemType.PowerBomb });
+        }
+
+        [Fact]
+        public void HiJumpLobbyMissilePreventsDeadEnd()
+        {
+            var progression = new Progression(new[] { ItemType.Flute, ItemType.Morph, ItemType.Missile }, new List<RewardType>(), new List<BossType>());
+            var missingItems = Logic.GetMissingRequiredItems(World.FindLocation(LocationId.UpperNorfairHiJumpEnergyTankLeft), progression, out _);
+            missingItems.Should().ContainEquivalentOf(new[] { ItemType.Bombs });
         }
     }
 }

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -26,7 +26,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
     {
         // If this test breaks, update Smz3Randomizer.Version
         [Theory]
-        [InlineData("test", -787405869)] // Smz3Randomizer v5.0
+        [InlineData("test", -787405869)] // Smz3Randomizer v5.1
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
             var filler = new StandardFiller(GetLogger<StandardFiller>());


### PR DESCRIPTION
This technically changes the logic a tiny bit, so maybe we should wait until the next version? I set the version number to 9.8.1, in anticipation of that conclusion.