### PR TITLE
#505: Implemented auto-pegging

### DIFF
--- a/src/Randomizer.Abstractions/TrackerBase.cs
+++ b/src/Randomizer.Abstractions/TrackerBase.cs
@@ -697,10 +697,16 @@ public abstract class TrackerBase
         bool autoTracked = false, ItemData? metadata = null);
 
     /// <summary>
-    /// Pegs a Peg World peg.
+    /// Pegs a Peg World peg, incrementing the count by one.
     /// </summary>
     /// <param name="confidence">The speech recognition confidence.</param>
     public abstract void Peg(float? confidence = null);
+
+    /// <summary>
+    /// Sets the Peg World peg count to the given value.
+    /// </summary>
+    /// <param name="count">The new count of hammered pegs.</param>
+    public abstract void Pegs(int count);
 
     /// <summary>
     /// Starts Peg World mode.

--- a/src/Randomizer.Abstractions/TrackerBase.cs
+++ b/src/Randomizer.Abstractions/TrackerBase.cs
@@ -706,7 +706,7 @@ public abstract class TrackerBase
     /// Sets the Peg World peg count to the given value.
     /// </summary>
     /// <param name="count">The new count of hammered pegs.</param>
-    public abstract void Pegs(int count);
+    public abstract void SetPegs(int count);
 
     /// <summary>
     /// Starts Peg World mode.

--- a/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
@@ -767,7 +767,7 @@ namespace Randomizer.App.Windows
             });
             TrackerBase.PegPegged += (sender, e) => Dispatcher.Invoke(() =>
             {
-                TogglePegWorld(TrackerBase.PegsPegged < PegWorldModeModule.TotalPegs);
+                TogglePegWorld(e.AutoTracked || TrackerBase.PegsPegged < PegWorldModeModule.TotalPegs);
                 RefreshGridItems();
             });
             TrackerBase.DungeonUpdated += (sender, e) => Dispatcher.Invoke(() =>

--- a/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
@@ -233,9 +233,14 @@ namespace Randomizer.Data.Configuration.ConfigFiles
         public SchrodingersString? PegWorldModeOn { get; init; }
 
         /// <summary>
-        /// Gets the phrases to respond with when pegging a Peg World peg.
+        /// Gets the phrases to respond with when pegging a single Peg World peg.
         /// </summary> = new()
         public SchrodingersString? PegWorldModePegged { get; init; }
+
+        /// <summary>
+        /// Gets the phrases to respond with when pegging multiple Peg World pegs.
+        /// </summary> = new()
+        public Dictionary<int, SchrodingersString>? PegWorldModePeggedMultiple { get; init; }
 
         /// <summary>
         /// Gets the phrases to respond with when all Peg World pegs have been

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/PegWorld.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/PegWorld.cs
@@ -45,7 +45,7 @@ public class PegWorld(TrackerBase tracker, ISnesConnectorService snesConnector) 
 
                 if (count != null)
                 {
-                    tracker.Pegs((int)count);
+                    tracker.SetPegs((int)count);
                 }
             }
         });

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/PegWorld.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/PegWorld.cs
@@ -1,0 +1,53 @@
+﻿using Randomizer.Abstractions;
+using Randomizer.Data.Tracking;
+using SnesConnectorLibrary;
+using SnesConnectorLibrary.Requests;
+using SNI;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks;
+
+/// <summary>
+/// Zelda State check for tracking how many Peg World pegs have been hammered
+/// </summary>
+public class PegWorld(TrackerBase tracker, ISnesConnectorService snesConnector) : IZeldaStateCheck
+{
+    /// <summary>
+    /// Executes the check for the current state
+    /// </summary>
+    /// <param name="tracker">The tracker instance</param>
+    /// <param name="currentState">The current state in Zelda</param>
+    /// <param name="prevState">The previous state in Zelda</param>
+    /// <returns>True if the check was identified, false otherwise</returns>
+    public bool ExecuteCheck(TrackerBase tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+    {
+        if (currentState.OverworldScreen == 0x62)
+        {
+            CountPegs();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void CountPegs()
+    {
+        snesConnector.MakeMemoryRequest(new SnesSingleMemoryRequest()
+        {
+            MemoryRequestType = SnesMemoryRequestType.RetrieveMemory,
+            SnesMemoryDomain = SnesMemoryDomain.ConsoleRAM,
+            AddressFormat = AddressFormat.Snes9x,
+            SniMemoryMapping = MemoryMapping.ExHiRom,
+            Address = 0x7e04c8,
+            Length = 0x01, // This is actually a four-byte value, but practically, only the lowest byte is important
+            OnResponse = (data, _) =>
+            {
+                var count = data.ReadUInt8(0);
+
+                if (count != null)
+                {
+                    tracker.Pegs((int)count);
+                }
+            }
+        });
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2111,6 +2111,38 @@ public sealed class Tracker : TrackerBase, IDisposable
         RestartIdleTimers();
     }
 
+    public override void Pegs(int count)
+    {
+        if (count <= PegsPegged)
+            return;
+
+        if (!PegWorldMode)
+        {
+            PegWorldMode = true;
+            OnToggledPegWorldModeOn(new TrackerEventArgs(null, true));
+        }
+
+        if (count <= PegWorldModeModule.TotalPegs)
+        {
+            var delta = count - PegsPegged;
+            var responseIndex = 0;
+
+            PegsPegged = count;
+
+            // Find the response with the closest value to the target delta, without being higher
+            for (var i = 0; i <= delta; i++)
+            {
+                if (Responses.PegWorldModePeggedMultiple?.ContainsKey(i) == true)
+                {
+                    responseIndex = i;
+                }
+            }
+
+            Say(x => x.PegWorldModePeggedMultiple?[responseIndex], delta);
+            OnPegPegged(new TrackerEventArgs(null, true));
+        }
+    }
+
     /// <summary>
     /// Starts Peg World mode.
     /// </summary>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2111,7 +2111,7 @@ public sealed class Tracker : TrackerBase, IDisposable
         RestartIdleTimers();
     }
 
-    public override void Pegs(int count)
+    public override void SetPegs(int count)
     {
         if (count <= PegsPegged)
             return;


### PR DESCRIPTION
So this didn't feel *great*, but it worked. I wanted to encapsulate this check in its own class, but I was having a hard time working out how to get the *difference* between the old value and the new value while also only performing the check while on the Pegworld overworld screen.

Here's what the initial batch of responses would look like, in `Sassy/responses.yml`:

```
PegWorldModePeggedMultiple:
  1:
  - Text: Pop.
  - Text: Poop.
    Weight: 0.001
  - Text: Plop.
    Weight: 0.001
  2:
  - Text: Popop
  3:
  - Text: Popopop
  4:
  - Text: Popopopop
  5:
  - Text: Popopopopop
  6:
  - Text: Popopopopopop
  7:
  - Text: Popopopopopopop
```

I figure we could add rare variants with the same number of syllables, like "papa papa", "Parapa Palace", and "PaRappa the Rapper".

Anyway, let me know if I missed a better way to organize this code!