### PR TITLE
Verify config string randomizer version

### DIFF
--- a/src/Randomizer.CrossPlatform/Views/GenerationSettingsBasicPanel.axaml.cs
+++ b/src/Randomizer.CrossPlatform/Views/GenerationSettingsBasicPanel.axaml.cs
@@ -219,7 +219,36 @@ public partial class GenerationSettingsBasicPanel : UserControl
 
     private void ImportSeedButton_OnClick(object? sender, RoutedEventArgs e)
     {
-        _generationSettingsWindowService?.ApplyConfig(Data.Basic.ImportString, true);
+        if (_generationSettingsWindowService == null)
+        {
+            return;
+        }
+
+        if (_generationSettingsWindowService.VerifyConfigVersion(Data.Basic.ImportString, out var versionMismatch))
+        {
+            _generationSettingsWindowService?.ApplyConfig(Data.Basic.ImportString, true);
+        }
+        else if (versionMismatch)
+        {
+            var messageWindow = new MessageWindow(new MessageWindowRequest()
+            {
+                Message = "The randomizer version of the import settings string does not match the current application's version. Using the seed number in this version may produce different results from the original seed. Do you want to continue?",
+                Title = "SMZ3 Cas' Randomizer",
+                Buttons = MessageWindowButtons.YesNo,
+                Icon = MessageWindowIcon.Warning
+            });
+
+            messageWindow.Closed += (o, args) =>
+            {
+                if (messageWindow.DialogResult?.PressedAcceptButton == true)
+                {
+                    _generationSettingsWindowService?.ApplyConfig(Data.Basic.ImportString, true);
+                }
+            };
+
+            messageWindow.ShowDialog(ParentWindow);
+        }
+
     }
 
     private void ImportSettingsButton_OnClick(object? sender, RoutedEventArgs e)

--- a/src/Randomizer.Data/Options/Config.cs
+++ b/src/Randomizer.Data/Options/Config.cs
@@ -218,7 +218,7 @@ namespace Randomizer.Data.Options
         public bool OpenPyramid { get; set; }
         public int TourianBossCount { get; set; }  = 4;
         public IDictionary<string, int> ItemOptions { get; set; } = new Dictionary<string, int>();
-
+        public string? RandomizerVersion { get; set; }
         [System.Text.Json.Serialization.JsonIgnore, JsonIgnore]
         public bool IsLocalConfig { get; set; } = true;
 
@@ -237,6 +237,7 @@ namespace Randomizer.Data.Options
         /// <returns>The string representation</returns>
         public static string ToConfigString(Config config, bool compress)
         {
+            config.RandomizerVersion = Data.RandomizerVersion.VersionString;
             var json = JsonSerializer.Serialize(config, s_options);
             if (!compress) return json;
             var buffer = Encoding.UTF8.GetBytes(json);

--- a/src/Randomizer.Data/RandomizerVersion.cs
+++ b/src/Randomizer.Data/RandomizerVersion.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Randomizer.Data;
+
+public class RandomizerVersion
+{
+    // Update this whenever we have breaking logic changes which might affect
+    // old seeds. Only use the major version number.
+    public static Version Version => new(6, 0);
+
+    public static string VersionString => Version.ToString();
+
+    public static int MajorVersion => Version.Major;
+}

--- a/src/Randomizer.Data/Services/GenerationSettingsWindowService.cs
+++ b/src/Randomizer.Data/Services/GenerationSettingsWindowService.cs
@@ -141,6 +141,35 @@ public class GenerationSettingsWindowService(SpriteService spriteService, Option
         UpdateSummaryText();
     }
 
+    public bool VerifyConfigVersion(string config, out bool versionMismatch)
+    {
+        try
+        {
+            var configObject = Config.FromConfigString(config.Trim()).FirstOrDefault();
+            if (configObject == null)
+            {
+                ConfigError?.Invoke(this, EventArgs.Empty);
+                versionMismatch = false;
+                return false;
+            }
+
+            versionMismatch = !VerifyConfigVersion(configObject);
+            return !versionMismatch;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Unable to parse config string");
+            ConfigError?.Invoke(this, EventArgs.Empty);
+            versionMismatch = false;
+            return false;
+        }
+    }
+
+    public bool VerifyConfigVersion(Config config)
+    {
+        return config.RandomizerVersion == RandomizerVersion.VersionString;
+    }
+
     public void SaveSettings()
     {
         _options.SeedOptions.Seed = _model.Basic.Seed;

--- a/src/Randomizer.SMZ3/FileData/Patches/MetadataPatch.cs
+++ b/src/Randomizer.SMZ3/FileData/Patches/MetadataPatch.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Randomizer.Data;
 using Randomizer.Shared;
 using Randomizer.SMZ3.Generation;
 
@@ -58,8 +59,8 @@ public class MetadataPatch : RomPatch
             ((_data.World.Config.Race ? 1 : 0) << 15) |
             ((_data.World.Config.Keysanity ? 1 : 0) << 13) |
             ((GetPatchesRequest.EnableMultiworld ? 1 : 0) << 12) |
-            (Smz3Randomizer.Version.Major << 4) |
-            (Smz3Randomizer.Version.Minor << 0);
+            (RandomizerVersion.Version.Major << 4) |
+            (RandomizerVersion.Version.Minor << 0);
 
         yield return new GeneratedPatch(Snes(0x80FF50), UshortBytes(_data.World.Id));
         yield return new GeneratedPatch(Snes(0x80FF52), UshortBytes(configField));

--- a/src/Randomizer.SMZ3/Generation/RomGenerationService.cs
+++ b/src/Randomizer.SMZ3/Generation/RomGenerationService.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using MSURandomizerLibrary;
 using MSURandomizerLibrary.Models;
 using MSURandomizerLibrary.Services;
+using Randomizer.Data;
 using Randomizer.Data.GeneratedData;
 using Randomizer.Data.Interfaces;
 using Randomizer.Data.Options;
@@ -351,7 +352,7 @@ public class RomGenerationService : IRomGenerationService
             SpoilerPath = Path.GetRelativePath(options.RomOutputPath, spoilerPath),
             Date = DateTimeOffset.Now,
             Settings = settingsString,
-            GeneratorVersion = Smz3Randomizer.Version.Major,
+            GeneratorVersion = RandomizerVersion.MajorVersion,
             MultiplayerGameDetails = multiplayerGameDetails,
             MsuRandomizationStyle = options.PatchOptions.MsuRandomizationStyle,
             MsuShuffleStyle = options.PatchOptions.MsuShuffleStyle,

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -37,8 +37,6 @@ namespace Randomizer.SMZ3.Generation
 
         public static string Name => "Super Metroid & A Link to the Past Cas’ Randomizer";
 
-        public static Version Version => new(5, 1);
-
         protected IFiller Filler { get; }
 
         public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Some of the recent changes made me think this would be a good idea. If someone puts in an old config string into a newer version and presses the button pull in the seed number, it'll throw a warning that the generated seed may not match.

![image](https://github.com/TheTrackerCouncil/SMZ3Randomizer/assets/63823784/4ba931f7-b52f-471e-b445-bd831fbf00e0)
