### PR TITLE
Fixes various keysanity issues

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.8.0-rc4</Version>
+    <Version>9.8.0-rc.4</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.CrossPlatform/Services/TrackerMapWindowService.cs
+++ b/src/Randomizer.CrossPlatform/Services/TrackerMapWindowService.cs
@@ -255,6 +255,22 @@ public class TrackerMapWindowService(
                 }
             }
         }
+        else if (location.Type == TrackerMapLocation.MapLocationType.SMDoor && world.Config.MetroidKeysanity)
+        {
+            var item = itemService.FirstOrDefault(location.Name);
+            if (item?.Type.IsInCategory(ItemCategory.KeycardL1) == true)
+            {
+                image = "door1.png";
+            }
+            else if (item?.Type.IsInCategory(ItemCategory.KeycardL2) == true)
+            {
+                image = "door2.png";
+            }
+            else if (item?.Type.IsInCategory(ItemCategory.KeycardBoss) == true)
+            {
+                image = "doorb.png";
+            }
+        }
 
         if (!string.IsNullOrEmpty(image))
         {

--- a/src/Randomizer.Data/Configuration/ConfigFiles/ItemConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/ItemConfig.cs
@@ -844,19 +844,19 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                 new()
                 {
                     Item = "Level 1 Keycard",
-                    InternalItemType = ItemType.KeycardL1,
+                    InternalItemType = ItemType.CardL1,
                     Image = "smkey1.png",
                 },
                 new()
                 {
                     Item = "Level 2 Keycard",
-                    InternalItemType = ItemType.KeycardL2,
+                    InternalItemType = ItemType.CardL2,
                     Image = "smkey2.png",
                 },
                 new()
                 {
                     Item = "Boss Keycard",
-                    InternalItemType = ItemType.KeycardBoss,
+                    InternalItemType = ItemType.CardBoss,
                     Image = "smkeyboss.png",
                 },
             };

--- a/src/Randomizer.Data/Configuration/ConfigFiles/ItemConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/ItemConfig.cs
@@ -841,6 +841,24 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     InternalItemType = ItemType.CardLowerNorfairBoss,
                     Image = "smkeyboss.png",
                 },
+                new()
+                {
+                    Item = "Level 1 Keycard",
+                    InternalItemType = ItemType.KeycardL1,
+                    Image = "smkey1.png",
+                },
+                new()
+                {
+                    Item = "Level 2 Keycard",
+                    InternalItemType = ItemType.KeycardL2,
+                    Image = "smkey2.png",
+                },
+                new()
+                {
+                    Item = "Boss Keycard",
+                    InternalItemType = ItemType.KeycardBoss,
+                    Image = "smkeyboss.png",
+                },
             };
         }
 

--- a/src/Randomizer.Data/Configuration/ConfigTypes/ItemData.cs
+++ b/src/Randomizer.Data/Configuration/ConfigTypes/ItemData.cs
@@ -284,13 +284,13 @@ namespace Randomizer.Data.Configuration.ConfigTypes
         /// </remarks>
         public bool IsJunk(Config? config)
         {
+            if (config?.ZeldaKeysanity == true && InternalItemType.IsInAnyCategory(new[] { ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Map }))
+                return false;
+
+            if (config?.MetroidKeysanity == true && InternalItemType.IsInCategory(ItemCategory.Keycard))
+                return false;
+
             if (InternalItemType == ItemType.Nothing || InternalItemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.NonRandomized, ItemCategory.Compass }))
-                return true;
-
-            if (config?.ZeldaKeysanity == false && InternalItemType.IsInAnyCategory(new[] { ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Map }))
-                return true;
-
-            if (config?.MetroidKeysanity == false && InternalItemType.IsInCategory(ItemCategory.Keycard))
                 return true;
 
             return false;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Crocomire.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Crocomire.cs
@@ -1,6 +1,7 @@
 ﻿using Randomizer.Abstractions;
 using Randomizer.Data;
 using Randomizer.Data.Tracking;
+using Randomizer.Shared;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
 {
@@ -8,8 +9,9 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
     /// Metroid state check for nearing Crocomire
     /// Player is in the room above Crocomire and is near the door to Crocomire
     /// </summary>
-    public class Crocomire : IMetroidStateCheck
+    public class Crocomire(IItemService itemService) : IMetroidStateCheck
     {
+
         /// <summary>
         /// Executes the check for the current state
         /// </summary>
@@ -19,7 +21,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
         /// <returns>True if the check was identified, false otherwise</returns>
         public bool ExecuteCheck(TrackerBase tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
         {
-            if (currentState.CurrentRegion == 2 && currentState.CurrentRoomInRegion == 9 && currentState.SamusX >= 3000 && currentState.SamusY > 500)
+            if (currentState is { CurrentRegion: 2, CurrentRoomInRegion: 9, SamusX: >= 3000, SamusY: > 500 } && (!tracker.World.Config.MetroidKeysanity || itemService.IsTracked(ItemType.CardNorfairBoss)))
             {
                 tracker.SayOnce(x => x.AutoTracker.NearCrocomire, currentState.SuperMissiles, currentState.MaxSuperMissiles);
                 return true;

--- a/src/Randomizer.SMZ3/Generation/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/StandardFiller.cs
@@ -85,8 +85,7 @@ namespace Randomizer.SMZ3.Generation
                 {
                     _logger.LogDebug("Distributing dungeon items according to logic");
                     var worldLocations = world.Locations.Empty().Shuffle(Random);
-
-                    AssumedFill(dungeon, progression.Concat(keycards).Concat(assumedInventory).Concat(preferenceItems).ToList(), worldLocations, new[] { world }, cancellationToken);
+                    AssumedFill(dungeon, progression.Concat(world.ItemPools.Keycards).Concat(assumedInventory).Concat(preferenceItems).ToList(), worldLocations, new[] { world }, cancellationToken);
                 }
 
                 if (worldConfig.MetroidKeysanity)

--- a/src/Randomizer.SMZ3/Generation/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/StandardFiller.cs
@@ -75,7 +75,9 @@ namespace Randomizer.SMZ3.Generation
                 var dungeon = world.ItemPools.Dungeon.ToList();
                 var progression = world.ItemPools.Progression.ToList();
 
-                var preferenceItems = ApplyItemPoolPreferences(startingInventory, progression, niceItems, junkItems, world);
+                var keycards = worldConfig.MetroidKeysanity ? world.ItemPools.Keycards.ToList() : [];
+
+                var preferenceItems = ApplyItemPoolPreferences(startingInventory, progression, niceItems, junkItems, keycards, world);
 
                 InitialFillInOwnWorld(dungeon, progression, world, config, startingInventory);
 
@@ -83,13 +85,13 @@ namespace Randomizer.SMZ3.Generation
                 {
                     _logger.LogDebug("Distributing dungeon items according to logic");
                     var worldLocations = world.Locations.Empty().Shuffle(Random);
-                    var keyCards = world.ItemPools.Keycards;
-                    AssumedFill(dungeon, progression.Concat(keyCards).Concat(assumedInventory).Concat(preferenceItems).ToList(), worldLocations, new[] { world }, cancellationToken);
+
+                    AssumedFill(dungeon, progression.Concat(keycards).Concat(assumedInventory).Concat(preferenceItems).ToList(), worldLocations, new[] { world }, cancellationToken);
                 }
 
                 if (worldConfig.MetroidKeysanity)
                 {
-                    progressionItems.AddRange(world.ItemPools.Keycards);
+                    progressionItems.AddRange(keycards);
                 }
                 else
                 {
@@ -130,7 +132,7 @@ namespace Randomizer.SMZ3.Generation
             FastFill(junkItems, locations);
         }
 
-        private List<Item> ApplyItemPoolPreferences(List<Item> startingInventory, List<Item> progressionItems, List<Item> niceItems, List<Item> junkItems, World world)
+        private List<Item> ApplyItemPoolPreferences(List<Item> startingInventory, List<Item> progressionItems, List<Item> niceItems, List<Item> junkItems, List<Item> keycards, World world)
         {
             var placedItems = new List<Item>();
             var config = world.Config;
@@ -190,6 +192,10 @@ namespace Randomizer.SMZ3.Generation
                     else if (junkItems.Any(x => x.Type == itemType))
                     {
                         placedItems.Add(FillItemAtLocation(junkItems, itemType, location));
+                    }
+                    else if (keycards.Any(x => x.Type == itemType))
+                    {
+                        placedItems.Add(FillItemAtLocation(keycards, itemType, location));
                     }
                     else if (progressionItems.Any(x => x.Type == itemType))
                     {

--- a/src/Randomizer.Shared/Enums/ItemCategory.cs
+++ b/src/Randomizer.Shared/Enums/ItemCategory.cs
@@ -46,6 +46,21 @@
         Keycard,
 
         /// <summary>
+        /// The item is a keycard for a level 1 door in Super Metroid.
+        /// </summary>
+        KeycardL1,
+
+        /// <summary>
+        /// The item is a keycard for a level 2 door in Super Metroid.
+        /// </summary>
+        KeycardL2,
+
+        /// <summary>
+        /// The item is a keycard for a boss door in Super Metroid.
+        /// </summary>
+        KeycardBoss,
+
+        /// <summary>
         /// The item is not worth paying 500 rupees for, but not necessarily
         /// junk.
         /// </summary>

--- a/src/Randomizer.Shared/Enums/ItemType.cs
+++ b/src/Randomizer.Shared/Enums/ItemType.cs
@@ -401,67 +401,67 @@ namespace Randomizer.Shared
         ArrowUpgrade10 = 0x54,
 
         [Description("Crateria Level 1 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL1)]
         CardCrateriaL1 = 0xD0,
 
         [Description("Crateria Level 2 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL2)]
         CardCrateriaL2 = 0xD1,
 
         [Description("Crateria Boss Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
         CardCrateriaBoss = 0xD2,
 
         [Description("Brinstar Level 1 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL1)]
         CardBrinstarL1 = 0xD3,
 
         [Description("Brinstar Level 2 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL2)]
         CardBrinstarL2 = 0xD4,
 
         [Description("Brinstar Boss Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
         CardBrinstarBoss = 0xD5,
 
         [Description("Norfair Level 1 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL1)]
         CardNorfairL1 = 0xD6,
 
         [Description("Norfair Level 2 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL2)]
         CardNorfairL2 = 0xD7,
 
         [Description("Norfair Boss Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
         CardNorfairBoss = 0xD8,
 
         [Description("Maridia Level 1 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL1)]
         CardMaridiaL1 = 0xD9,
 
         [Description("Maridia Level 2 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL2)]
         CardMaridiaL2 = 0xDA,
 
         [Description("Maridia Boss Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
         CardMaridiaBoss = 0xDB,
 
         [Description("Wrecked Ship Level 1 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL1)]
         CardWreckedShipL1 = 0xDC,
 
         [Description("Wrecked Ship Boss Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
         CardWreckedShipBoss = 0xDD,
 
         [Description("Lower Norfair Level 1 Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardL1)]
         CardLowerNorfairL1 = 0xDE,
 
         [Description("Lower Norfair Boss Keycard")]
-        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
         CardLowerNorfairBoss = 0xDF,
 
         [Description("Missile")]
@@ -587,5 +587,17 @@ namespace Randomizer.Shared
         [Description("Bee Refill")]
         [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BeeContent = 0x0E,
+
+        [Description("Level 1 Keycard")]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.NonRandomized, ItemCategory.Keycard, ItemCategory.KeycardL1)]
+        KeycardL1 = 0xF0,
+
+        [Description("Level 2 Keycard")]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.NonRandomized, ItemCategory.Keycard, ItemCategory.KeycardL2)]
+        KeycardL2 = 0xF1,
+
+        [Description("Boss Keycard")]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.NonRandomized, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
+        KeycardBoss = 0xF2,
     }
 }

--- a/src/Randomizer.Shared/Enums/ItemType.cs
+++ b/src/Randomizer.Shared/Enums/ItemType.cs
@@ -590,14 +590,14 @@ namespace Randomizer.Shared
 
         [Description("Level 1 Keycard")]
         [ItemCategory(ItemCategory.Metroid, ItemCategory.NonRandomized, ItemCategory.Keycard, ItemCategory.KeycardL1)]
-        KeycardL1 = 0xF0,
+        CardL1 = 0xF0,
 
         [Description("Level 2 Keycard")]
         [ItemCategory(ItemCategory.Metroid, ItemCategory.NonRandomized, ItemCategory.Keycard, ItemCategory.KeycardL2)]
-        KeycardL2 = 0xF1,
+        CardL2 = 0xF1,
 
         [Description("Boss Keycard")]
         [ItemCategory(ItemCategory.Metroid, ItemCategory.NonRandomized, ItemCategory.Keycard, ItemCategory.KeycardBoss)]
-        KeycardBoss = 0xF2,
+        CardBoss = 0xF2,
     }
 }

--- a/src/Randomizer.Shared/Enums/ItemTypeExtensions.cs
+++ b/src/Randomizer.Shared/Enums/ItemTypeExtensions.cs
@@ -68,14 +68,14 @@ namespace Randomizer.Shared.Enums
         /// </returns>
         public static bool IsPossibleProgression(this ItemType itemType, bool isZeldaKeysanity, bool isMetroidKeysanity)
         {
-            if (itemType == ItemType.Nothing || itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.NonRandomized, ItemCategory.Map, ItemCategory.Compass, ItemCategory.Nice }))
-                return false;
-
             if (itemType.IsInAnyCategory(new[] { ItemCategory.SmallKey, ItemCategory.BigKey }))
                 return isZeldaKeysanity;
 
             if (itemType.IsInCategory(ItemCategory.Keycard))
                 return isMetroidKeysanity;
+
+            if (itemType == ItemType.Nothing || itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.NonRandomized, ItemCategory.Map, ItemCategory.Compass, ItemCategory.Nice }))
+                return false;
 
             return true;
         }
@@ -116,6 +116,18 @@ namespace Randomizer.Shared.Enums
             {
                 return true;
             }
+            else if (itemType.IsInCategory(ItemCategory.KeycardL1) && other.Value.IsInCategory(ItemCategory.KeycardL1))
+            {
+                return true;
+            }
+            else if (itemType.IsInCategory(ItemCategory.KeycardL2) && other.Value.IsInCategory(ItemCategory.KeycardL2))
+            {
+                return true;
+            }
+            else if (itemType.IsInCategory(ItemCategory.KeycardBoss) && other.Value.IsInCategory(ItemCategory.KeycardBoss))
+            {
+                return true;
+            }
 
             return false;
         }
@@ -127,7 +139,7 @@ namespace Randomizer.Shared.Enums
         public static ItemType GetGenericType(this ItemType itemType)
         {
             if (!itemType.IsInAnyCategory(ItemCategory.Bottle, ItemCategory.Compass, ItemCategory.Map,
-                    ItemCategory.SmallKey, ItemCategory.BigKey))
+                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.KeycardL1, ItemCategory.KeycardL2, ItemCategory.KeycardBoss))
             {
                 return itemType;
             }
@@ -146,6 +158,18 @@ namespace Randomizer.Shared.Enums
             else if (itemType.IsInCategory(ItemCategory.SmallKey))
             {
                 return ItemType.Key;
+            }
+            else if (itemType.IsInCategory(ItemCategory.KeycardL1))
+            {
+                return ItemType.KeycardL1;
+            }
+            else if (itemType.IsInCategory(ItemCategory.KeycardL2))
+            {
+                return ItemType.KeycardL2;
+            }
+            else if (itemType.IsInCategory(ItemCategory.KeycardBoss))
+            {
+                return ItemType.KeycardBoss;
             }
             else
             {

--- a/src/Randomizer.Shared/Enums/ItemTypeExtensions.cs
+++ b/src/Randomizer.Shared/Enums/ItemTypeExtensions.cs
@@ -161,15 +161,15 @@ namespace Randomizer.Shared.Enums
             }
             else if (itemType.IsInCategory(ItemCategory.KeycardL1))
             {
-                return ItemType.KeycardL1;
+                return ItemType.CardL1;
             }
             else if (itemType.IsInCategory(ItemCategory.KeycardL2))
             {
-                return ItemType.KeycardL2;
+                return ItemType.CardL2;
             }
             else if (itemType.IsInCategory(ItemCategory.KeycardBoss))
             {
-                return ItemType.KeycardBoss;
+                return ItemType.CardBoss;
             }
             else
             {


### PR DESCRIPTION
- Fixes #512 - Auto tracker spoiling keycard type
- Fixes #510 - Tracker states pre-croc announcement without the boss keycard
- Fixes an issue where keycards and Zelda keys would be shown as useless on the map
- Fixes the crossplatform version not showing Super Metroid doors on the map