### PR TITLE
Moved MSU Resume Cancel to new pre-shuffle event

### DIFF
--- a/src/TrackerCouncil.Smz3.Tracking/TrackerCouncil.Smz3.Tracking.csproj
+++ b/src/TrackerCouncil.Smz3.Tracking/TrackerCouncil.Smz3.Tracking.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BunLabs.Common" Version="1.0.4" />
-    <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="2.1.0" />
+    <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="2.2.0-beta.1" />
     <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />
     <PackageReference Include="SharpHook" Version="5.3.3" />
     <PackageReference Include="System.Speech" Version="8.0.0" />

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MsuModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MsuModule.cs
@@ -118,13 +118,13 @@ public class MsuModule : TrackerModule, IDisposable
         }
 
         msuMonitorService.MsuTrackChanged += MsuMonitorServiceOnMsuTrackChanged;
-        msuMonitorService.MsuShuffled += MsuMonitorServiceOnMsuShuffled;
+        msuMonitorService.PreMsuShuffle += MsuMonitorServiceOnPreMsuShuffle;
 
         _isSetup = true;
 
     }
 
-    private void MsuMonitorServiceOnMsuShuffled(object? sender, EventArgs e)
+    private void MsuMonitorServiceOnPreMsuShuffle(object? sender, EventArgs e)
     {
         _gameService.TryCancelMsuResume();
     }


### PR DESCRIPTION
Now wondering if we should do a cancel both in the pre-shuffle _and_ the shuffled events. But this works.