### PR TITLE
Collapsed `Tracker.Say()` into one overload with many optional arguments

### DIFF
--- a/src/TrackerCouncil.Smz3.Abstractions/TrackerBase.cs
+++ b/src/TrackerCouncil.Smz3.Abstractions/TrackerBase.cs
@@ -415,91 +415,31 @@ public abstract class TrackerBase
     /// <summary>
     /// Speak a sentence using text-to-speech.
     /// </summary>
-    /// <param name="text">The possible sentences to speak.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if <paramref
-    /// name="text"/> was <c>null</c>.
-    /// </returns>
-    public abstract bool Say(SchrodingersString? text);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech.
-    /// </summary>
     /// <param name="selectResponse">Selects the response to use.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
-    /// response was <c>null</c>.
-    /// </returns>
-    public abstract bool Say(Func<ResponseConfig, SchrodingersString?> selectResponse);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech.
-    /// </summary>
-    /// <param name="text">The possible sentences to speak.</param>
-    /// <param name="args">The arguments used to format the text.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if <paramref
-    /// name="text"/> was <c>null</c>.
-    /// </returns>
-    public abstract bool Say(SchrodingersString? text, params object?[] args);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech.
-    /// </summary>
-    /// <param name="selectResponse">Selects the response to use.</param>
-    /// <param name="args">The arguments used to format the text.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
-    /// response was <c>null</c>.
-    /// </returns>
-    public abstract bool Say(Func<ResponseConfig, SchrodingersString?> selectResponse, params object?[] args);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech only one time.
-    /// </summary>
-    /// <param name="text">The possible sentences to speak.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if <paramref
-    /// name="text"/> was <c>null</c>.
-    /// </returns>
-    public abstract bool SayOnce(SchrodingersString? text);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech only one time.
-    /// </summary>
-    /// <param name="selectResponse">Selects the response to use.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
-    /// response was <c>null</c>.
-    /// </returns>
-    public abstract bool SayOnce(Func<ResponseConfig, SchrodingersString?> selectResponse);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech only one time.
-    /// </summary>
-    /// <param name="text">The text response to use.</param>
-    /// <param name="args">Arguments to substitute out in the text</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
-    /// response was <c>null</c>.
-    /// </returns>
-    public abstract bool SayOnce(SchrodingersString? text, params object?[] args);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech only one time.
-    /// </summary>
-    /// <param name="selectResponse">Selects the response to use.</param>
-    /// <param name="args">The arguments used to format the text.</param>
-    /// <returns>
-    /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
-    /// response was <c>null</c>.
-    /// </returns>
-    public abstract bool SayOnce(Func<ResponseConfig, SchrodingersString?> selectResponse, params object?[] args);
-
-    /// <summary>
-    /// Speak a sentence using text-to-speech.
-    /// </summary>
-    /// <param name="text">The phrase to speak.</param>
+    /// <param name="selectResponses">
+    /// Selects the dictionary of responses that <c>key</c> or <c>tieredKey</c> will pull a response from.
+    /// </param>
+    /// <param name="response">The response to use.</param>
+    /// <param name="responses">
+    /// The dictionary of responses that <c>key</c> or <c>tieredKey</c> will pull a response from.
+    /// </param>
+    /// <param name="key">
+    /// The exact key of the response that should be pulled from the dictionary of <c>responses</c>.
+    /// </param>
+    /// <param name="tieredKey">
+    /// The "tiered" key of the response that should be pulled from the dictionary of <c>responses</c>.
+    /// The closest key in the dictionary that is less than or equal to this value will be used.
+    /// </param>
+    /// <param name="args">
+    /// The arguments used to format the selected response.
+    /// This paremeter is ignored when the <c>text</c> parameter is specified.
+    /// </param>
+    /// <param name="text">The specific sentence that should be spoken, which may include placeholders.</param>
+    /// <param name="once">
+    /// <c>true</c> to speak the selected response only once or
+    /// <c>false</c> to speak it as many times as requested. The default is <c>false</c>.
+    /// This parameter is ignored when the <c>text</c> parameter is specified.
+    /// </param>
     /// <param name="wait">
     /// <c>true</c> to wait until the text has been spoken completely or
     /// <c>false</c> to immediately return. The default is <c>false</c>.
@@ -508,7 +448,17 @@ public abstract class TrackerBase
     /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
     /// response was <c>null</c>.
     /// </returns>
-    public abstract bool Say(string? text, bool wait = false);
+    public abstract bool Say(
+        Func<ResponseConfig, SchrodingersString?>? selectResponse = null,
+        Func<ResponseConfig, Dictionary<int, SchrodingersString>?>? selectResponses = null,
+        SchrodingersString? response = null,
+        Dictionary<int, SchrodingersString>? responses = null,
+        int? key = null,
+        int? tieredKey = null,
+        object?[]? args = null,
+        string? text = null,
+        bool once = false,
+        bool wait = false);
 
     /// <summary>
     /// Repeats the most recently spoken sentence using text-to-speech at a

--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
@@ -163,7 +163,7 @@ public class AutoTrackerConfig : IMergeable<AutoTrackerConfig>
     /// Responses based on what number the GT key was. Tracker will use the responses for the largest number less
     /// than the number of the GT key.
     /// </summary>
-    public Dictionary<int, SchrodingersString?>? GTKeyResponses { get; init; }
+    public Dictionary<int, SchrodingersString>? GTKeyResponses { get; init; }
 
     /// <summary>
     /// Auto tracker detected switching to SMZ3

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTracker.cs
@@ -175,18 +175,10 @@ public class AutoTracker : AutoTrackerBase
 
         var chatIntegrationModule = _trackerModuleFactory.GetModule<ChatIntegrationModule>();
         _numGTItems++;
-        TrackerBase.Say(_numGTItems.ToString());
+        TrackerBase.Say(text: _numGTItems.ToString());
         if (location.Item.Type == ItemType.BigKeyGT)
         {
-            var responseIndex = 1;
-            for (var i = 1; i <= _numGTItems; i++)
-            {
-                if (TrackerBase.Responses.AutoTracker.GTKeyResponses?.ContainsKey(i) == true)
-                {
-                    responseIndex = i;
-                }
-            }
-            TrackerBase.Say(x => x.AutoTracker.GTKeyResponses?[responseIndex], _numGTItems);
+            TrackerBase.Say(selectResponses: x => x.AutoTracker.GTKeyResponses, tieredKey: _numGTItems, args: [_numGTItems]);
             chatIntegrationModule?.GTItemTracked(_numGTItems, true);
             _foundGTKey = true;
         }

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTrackerModules/GameMonitor.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTrackerModules/GameMonitor.cs
@@ -56,11 +56,11 @@ public class GameMonitor(TrackerBase tracker, ISnesConnectorService snesConnecto
             {
                 var worldCount = worldService.Worlds.Count;
                 var otherPlayerName = worldService.Worlds.Where(x => x != worldService.World).Random(new Random())!.Config.PhoneticName;
-                Tracker.Say(x => x.AutoTracker.GameStartedMultiplayer, worldCount, otherPlayerName);
+                Tracker.Say(x => x.AutoTracker.GameStartedMultiplayer, args: [worldCount, otherPlayerName]);
             }
             else
             {
-                Tracker.Say(x => x.AutoTracker.GameStarted, Tracker.Rom?.Seed);
+                Tracker.Say(x => x.AutoTracker.GameStarted, args: [Tracker.Rom?.Seed]);
             }
         }
     }

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Crocomire.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Crocomire.cs
@@ -22,7 +22,7 @@ public class Crocomire(IItemService itemService) : IMetroidStateCheck
     {
         if (currentState is { CurrentRegion: 2, CurrentRoomInRegion: 9, SamusX: >= 3000, SamusY: > 500 } && (!tracker.World.Config.MetroidKeysanity || itemService.IsTracked(ItemType.CardNorfairBoss)))
         {
-            tracker.SayOnce(x => x.AutoTracker.NearCrocomire, currentState.SuperMissiles, currentState.MaxSuperMissiles);
+            tracker.Say(x => x.AutoTracker.NearCrocomire, args: [currentState.SuperMissiles, currentState.MaxSuperMissiles], once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/CrumbleShaft.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/CrumbleShaft.cs
@@ -20,7 +20,7 @@ public class CrumbleShaft : IMetroidStateCheck
     {
         if (currentState.CurrentRegion == 2 && currentState.CurrentRoomInRegion == 8 && prevState.CurrentRoomInRegion == 4)
         {
-            tracker.SayOnce(x => x.AutoTracker.AtCrumbleShaft);
+            tracker.Say(x => x.AutoTracker.AtCrumbleShaft, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/KraidsAwfulSon.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/KraidsAwfulSon.cs
@@ -20,7 +20,7 @@ public class KraidsAwfulSon : IMetroidStateCheck
     {
         if (currentState.CurrentRegion == 1 && currentState.CurrentRoomInRegion == 45 && prevState.CurrentRoomInRegion == 44)
         {
-            tracker.SayOnce(x => x.AutoTracker.NearKraidsAwfulSon);
+            tracker.Say(x => x.AutoTracker.NearKraidsAwfulSon, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/MetroidDeath.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/MetroidDeath.cs
@@ -52,7 +52,7 @@ public class MetroidDeath : IMetroidStateCheck
 
         if (!silent && region is { Metadata.WhenDiedInRoom: not null } && currentState.CurrentRoomInRegion != null)
         {
-            tracker.SayOnce(region.Metadata.WhenDiedInRoom[currentState.CurrentRoomInRegion.Value]);
+            tracker.Say(response: region.Metadata.WhenDiedInRoom[currentState.CurrentRoomInRegion.Value], once: true);
         }
 
         tracker.TrackDeath(true);

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Mockball.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Mockball.cs
@@ -36,7 +36,7 @@ public class Mockball : IMetroidStateCheck
             && prevState.SamusX < 560
             && currentState.SamusX < 800)
         {
-            tracker.SayOnce(x => x.AutoTracker.MockBall);
+            tracker.Say(x => x.AutoTracker.MockBall, once: true);
             return true;
         }
         // Norfair Mockball
@@ -46,7 +46,7 @@ public class Mockball : IMetroidStateCheck
                  && prevState.SamusX > 1016
                  && currentState.SamusX > 800)
         {
-            tracker.SayOnce(x => x.AutoTracker.MockBall);
+            tracker.Say(x => x.AutoTracker.MockBall, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Ridley.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Ridley.cs
@@ -20,7 +20,7 @@ public class Ridley : IMetroidStateCheck
     {
         if (currentState.CurrentRegion == 2 && currentState.CurrentRoomInRegion == 37 && currentState.SamusX <= 375 && currentState.SamusX >= 100 && currentState.SamusY <= 200)
         {
-            tracker.SayOnce(x => x.AutoTracker.RidleyFace);
+            tracker.Say(x => x.AutoTracker.RidleyFace, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Shaktool.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/Shaktool.cs
@@ -25,7 +25,7 @@ public class Shaktool : IMetroidStateCheck
             tracker.World.AllBosses.FirstOrDefault(x => x.Name == "Shaktool")?.State.Defeated != true)
         {
             tracker.ShutUp();
-            tracker.SayOnce(x => x.AutoTracker.NearShaktool);
+            tracker.Say(x => x.AutoTracker.NearShaktool, once: true);
             tracker.StartShaktoolMode();
             return true;
         }

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/SporeSpawn.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/MetroidStateChecks/SporeSpawn.cs
@@ -20,7 +20,7 @@ public class SporeSpawn : IMetroidStateCheck
     {
         if (currentState.CurrentRegion == 1 && currentState.CurrentRoomInRegion == 22 && prevState.CurrentRoomInRegion == 9)
         {
-            tracker.SayOnce(x => x.AutoTracker.SkipSporeSpawn);
+            tracker.Say(selectResponse: x => x.AutoTracker.SkipSporeSpawn, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/DiverDown.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/DiverDown.cs
@@ -21,13 +21,13 @@ public class DiverDown : IZeldaStateCheck
         // Back diver down
         if (currentState.CurrentRoom == 118 && currentState.LinkX < 3474 && (currentState.LinkX < 3424 || currentState.LinkX > 3440) && currentState.LinkY <= 4000 && prevState.LinkY > 4000 && (currentState.LinkState is 0 or 6 or 3) && currentState.IsOnBottomHalfOfRoom && currentState.IsOnRightHalfOfRoom)
         {
-            trackerBase.SayOnce(x => x.AutoTracker.DiverDown);
+            trackerBase.Say(x => x.AutoTracker.DiverDown, once: true);
             return true;
         }
         // Left side diver down
         else if (currentState.CurrentRoom == 53 && currentState.PreviousRoom == 54 && currentState.LinkX > 2808 && currentState.LinkX < 2850 && currentState.LinkY <= 1940 && prevState.LinkY > 1940 && currentState.LinkX <= prevState.LinkX && (currentState.LinkState is 0 or 6 or 3))
         {
-            trackerBase.SayOnce(x => x.AutoTracker.DiverDown);
+            trackerBase.Say(x => x.AutoTracker.DiverDown, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
@@ -50,7 +50,7 @@ public class EnteredDungeon : IZeldaStateCheck
 
         if (!_worldAccessor.World.Config.ZeldaKeysanity && !_enteredDungeons.Contains(region) && dungeon.IsPendantDungeon)
         {
-            trackerBase.Say(trackerBase.Responses.AutoTracker.EnterPendantDungeon, dungeon.DungeonMetadata.Name, dungeon.DungeonReward?.Metadata.Name);
+            trackerBase.Say(x => x.AutoTracker.EnterPendantDungeon, args: [dungeon.DungeonMetadata.Name, dungeon.DungeonReward?.Metadata.Name]);
         }
         else if (!_worldAccessor.World.Config.ZeldaKeysanity && region is CastleTower)
         {
@@ -63,7 +63,7 @@ public class EnteredDungeon : IZeldaStateCheck
 
             if (clearedCrystalDungeonCount < trackerBase.World.Config.GanonsTowerCrystalCount)
             {
-                trackerBase.SayOnce(x => x.AutoTracker.EnteredGTEarly, clearedCrystalDungeonCount);
+                trackerBase.Say(x => x.AutoTracker.EnteredGTEarly, args: [clearedCrystalDungeonCount], once: true);
             }
         }
 

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/FallFromGanon.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/FallFromGanon.cs
@@ -20,7 +20,7 @@ public class FallFromGanon : IZeldaStateCheck
     {
         if (currentState.CurrentRoom == 16 && currentState.PreviousRoom == 0 && prevState.CurrentRoom == 0)
         {
-            trackerBase.SayOnce(x => x.AutoTracker.FallFromGanon);
+            trackerBase.Say(x => x.AutoTracker.FallFromGanon, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/FallFromMoldorm.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/FallFromMoldorm.cs
@@ -21,13 +21,13 @@ public class FallFromMoldorm : IZeldaStateCheck
         // Tower of Hera
         if (currentState.CurrentRoom == 23 && currentState.PreviousRoom == 7 && prevState.CurrentRoom == 7)
         {
-            trackerBase.SayOnce(x => x.AutoTracker.FallFromMoldorm);
+            trackerBase.Say(x => x.AutoTracker.FallFromMoldorm, once: true);
             return true;
         }
         // Ganon's Tower
         else if (currentState.CurrentRoom == 166 && currentState.PreviousRoom == 77 && prevState.CurrentRoom == 77)
         {
-            trackerBase.SayOnce(x => x.AutoTracker.FallFromGTMoldorm);
+            trackerBase.Say(x => x.AutoTracker.FallFromGTMoldorm, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/HeraPot.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/HeraPot.cs
@@ -20,7 +20,7 @@ public class HeraPot : IZeldaStateCheck
     {
         if (currentState.CurrentRoom == 167 && prevState.CurrentRoom == 119 && prevState.PreviousRoom != 49)
         {
-            trackerBase.SayOnce(x => x.AutoTracker.HeraPot);
+            trackerBase.Say(x => x.AutoTracker.HeraPot, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/IceBreaker.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/IceBreaker.cs
@@ -20,7 +20,7 @@ public class IceBreaker : IZeldaStateCheck
     {
         if (currentState.CurrentRoom == 31 && currentState.PreviousRoom == 30 && currentState.LinkX >= 8000 && prevState.LinkX < 8000 && currentState.IsOnRightHalfOfRoom && prevState.IsOnRightHalfOfRoom)
         {
-            trackerBase.SayOnce(x => x.AutoTracker.IceBreaker);
+            trackerBase.Say(x => x.AutoTracker.IceBreaker, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/SpeckyClip.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/SpeckyClip.cs
@@ -25,7 +25,7 @@ public class SpeckyClip : IZeldaStateCheck
             { LinkX: >= 3650, LinkX: <= 3696, LinkY: >= 1864, LinkY: <= 1872, CurrentRoom: 55 };
         if (inCorrectLocation && prevInWall && nowBelowWall)
         {
-            tracker.SayOnce(x => x.AutoTracker.SpeckyClip);
+            tracker.Say(x => x.AutoTracker.SpeckyClip, once: true);
             return true;
         }
         return false;

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
@@ -101,7 +101,7 @@ public class ViewedMap : IZeldaStateCheck
         {
             if (rewards.Count(x => x == RewardType.CrystalRed || x == RewardType.CrystalBlue) == 3)
             {
-                _tracker.SayOnce(x => x.AutoTracker.LightWorldAllCrystals);
+                _tracker.Say(x => x.AutoTracker.LightWorldAllCrystals, once: true);
             }
             else if (rewards.Count == 0)
             {
@@ -157,7 +157,7 @@ public class ViewedMap : IZeldaStateCheck
         {
             if (isMiseryMirePendant && isTurtleRockPendant)
             {
-                _tracker.SayOnce(x => x.AutoTracker.DarkWorldNoMedallions);
+                _tracker.Say(x => x.AutoTracker.DarkWorldNoMedallions, once: true);
             }
             else if (rewards.Count == 0)
             {

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaDeath.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaDeath.cs
@@ -31,11 +31,11 @@ public class ZeldaDeath(IItemService itemService) : IZeldaStateCheck
             var region = tracker.CurrentRegion as Z3Region;
             if (region is { IsOverworld: true } && prevState.OverworldScreen != null && tracker.CurrentRegion?.Metadata.WhenDiedInRoom?.TryGetValue(prevState.OverworldScreen.Value, out var locationResponse) == true)
             {
-                tracker.Say(locationResponse);
+                tracker.Say(response: locationResponse);
             }
             else if (region is { IsOverworld: false } && prevState.CurrentRoom != null && tracker.CurrentRegion?.Metadata.WhenDiedInRoom?.TryGetValue(prevState.CurrentRoom.Value, out locationResponse) == true)
             {
-                tracker.Say(locationResponse);
+                tracker.Say(response: locationResponse);
             }
         }
 

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/ChatIntegrationModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/ChatIntegrationModule.cs
@@ -110,7 +110,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
         TrackerBase.Say(x => x.Chat.StartedGuessingGame);
 
         await Task.Delay(s_random.Next(100, 900));
-        TrackerBase.Say(x => x.Chat.TrackerGuess, _trackerGuess);
+        TrackerBase.Say(x => x.Chat.TrackerGuess, args: [_trackerGuess]);
 
         TrackerBase.AddUndo(() =>
         {
@@ -142,7 +142,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
         {
             TrackerBase.Say(x => isModerator
                 ? x.Chat.ModeratorClosedGuessingGameBeforeStarting
-                : x.Chat.ClosedGuessingGameBeforeStarting, moderator);
+                : x.Chat.ClosedGuessingGameBeforeStarting, args: [moderator]);
             return;
         }
 
@@ -153,7 +153,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
             {
                 TrackerBase.Say(x => isModerator
                     ? x.Chat.ModeratorClosedGuessingGameWhileClosed
-                    : x.Chat.ClosedGuessingGameWhileClosed, moderator);
+                    : x.Chat.ClosedGuessingGameWhileClosed, args: [moderator]);
             }
             return;
         }
@@ -173,7 +173,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
         }
         else
         {
-            TrackerBase.Say(x => x.Chat.ModeratorClosedGuessingGame, moderator);
+            TrackerBase.Say(x => x.Chat.ModeratorClosedGuessingGame, args: [moderator]);
         }
 
         TrackerBase.AddUndo(() =>
@@ -226,11 +226,11 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
         {
             if (winningNumber == _trackerGuess)
             {
-                TrackerBase.Say(x => x.Chat.TrackerGuessOnlyWinner, winningNumber);
+                TrackerBase.Say(x => x.Chat.TrackerGuessOnlyWinner, args: [winningNumber]);
             }
             else
             {
-                TrackerBase.Say(x => x.Chat.NobodyWonGuessingGame, winningNumber);
+                TrackerBase.Say(x => x.Chat.NobodyWonGuessingGame, args: [winningNumber]);
             }
 
             var chatMessage = TrackerBase.Responses.Chat.NobodyWonGuessingGame?.Format(winningNumber);
@@ -247,7 +247,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
             var pronouncedNames = winners.Select(TrackerBase.CorrectUserNamePronunciation);
             if (currentValue == winningNumber)
             {
-                TrackerBase.Say(x => x.Chat.DeclareGuessingGameWinners, winningNumber, NaturalLanguage.Join(pronouncedNames));
+                TrackerBase.Say(x => x.Chat.DeclareGuessingGameWinners, args: [winningNumber, NaturalLanguage.Join(pronouncedNames)]);
                 var chatMessage = TrackerBase.Responses.Chat.DeclareGuessingGameWinners?.Format(winningNumber, NaturalLanguage.Join(winners));
                 if (chatMessage != null)
                 {
@@ -256,7 +256,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
             }
             else
             {
-                TrackerBase.Say(x => x.Chat.DeclareGuessingGameClosestButNotOverWinner, winningNumber, currentValue, NaturalLanguage.Join(pronouncedNames));
+                TrackerBase.Say(x => x.Chat.DeclareGuessingGameClosestButNotOverWinner, args: [winningNumber, currentValue, NaturalLanguage.Join(pronouncedNames)]);
                 var chatMessage = TrackerBase.Responses.Chat.DeclareGuessingGameClosestButNotOverWinner?.Format(winningNumber, currentValue, NaturalLanguage.Join(winners));
                 if (chatMessage != null)
                 {
@@ -267,12 +267,12 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
             if (winningNumber == _trackerGuess)
             {
                 await Task.Delay(s_random.Next(100, 900));
-                TrackerBase.Say(x => x.Chat.TrackerGuessWon, winningNumber);
+                TrackerBase.Say(x => x.Chat.TrackerGuessWon, args: [winningNumber]);
             }
         }
 
         if (winningNumber < _trackerGuess || (winningNumber != _trackerGuess && !isAutoTracked))
-            TrackerBase.Say(x => x.Chat.TrackerGuessFailed, winningNumber);
+            TrackerBase.Say(x => x.Chat.TrackerGuessFailed, args: [winningNumber]);
     }
 
     /// <summary>
@@ -288,7 +288,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
 
         if (!wasBigKey && number == _trackerGuess)
         {
-            TrackerBase.Say(x => x.Chat.TrackerGuessFailed, number);
+            TrackerBase.Say(x => x.Chat.TrackerGuessFailed, args: [number]);
         }
         else if (wasBigKey)
         {
@@ -327,7 +327,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
         }
 
         TrackerBase.Say(x => x.Chat.AskChatAboutContent);
-        TrackerBase.Say(x => x.Chat.PollOpened, _askChatAboutContentPollTime);
+        TrackerBase.Say(x => x.Chat.PollOpened, args: [_askChatAboutContentPollTime]);
         _askChatAboutContentCheckPollResults = true;
         _hasAskedChatAboutContent = true;
 
@@ -455,7 +455,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
                 if (message.SenderUserName.Equals(TrackerBase.Options.UserName)
                     && TrackerBase.Responses.Chat.GreetedChannel != null)
                 {
-                    TrackerBase.Say(x => x.Chat.GreetedChannel, senderNamePronunciation);
+                    TrackerBase.Say(x => x.Chat.GreetedChannel, args: [senderNamePronunciation]);
                     break;
                 }
 
@@ -465,12 +465,12 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
                     if (greeted >= 2)
                         break;
 
-                    TrackerBase.Say(x => x.Chat.GreetedTwice, senderNamePronunciation);
+                    TrackerBase.Say(x => x.Chat.GreetedTwice, args: [senderNamePronunciation]);
                     _usersGreetedTimes[message.Sender]++;
                 }
                 else
                 {
-                    TrackerBase.Say(x => x.Chat.GreetingResponses, senderNamePronunciation);
+                    TrackerBase.Say(x => x.Chat.GreetingResponses, args: [senderNamePronunciation]);
                     _usersGreetedTimes.Add(message.Sender, 1);
                 }
                 break;

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/HintTileModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/HintTileModule.cs
@@ -49,12 +49,12 @@ public class HintTileModule : TrackerModule
             {
                 var hintTile = GetHintTileFromResult(result);
                 var text = _gameHintService.GetHintTileText(hintTile.PlayerHintTile, WorldService.World, WorldService.Worlds);
-                TrackerBase.Say(_hintTileConfig.RequestedHintTile, text);
+                TrackerBase.Say(response: _hintTileConfig.RequestedHintTile, args: [text]);
                 TrackerBase.UpdateHintTile(hintTile.PlayerHintTile);
             }
             else
             {
-                TrackerBase.Say(_hintTileConfig.NoHintTiles);
+                TrackerBase.Say(response: _hintTileConfig.NoHintTiles);
             }
 
         });
@@ -64,7 +64,7 @@ public class HintTileModule : TrackerModule
             var hintTile = TrackerBase.LastViewedHintTile;
             if (hintTile?.State == null)
             {
-                TrackerBase.Say(_hintTileConfig.NoPreviousHintTile);
+                TrackerBase.Say(response: _hintTileConfig.NoPreviousHintTile);
             }
             else if (hintTile.State.HintState != HintState.Cleared && hintTile.Locations?.Count() > 0)
             {
@@ -78,12 +78,12 @@ public class HintTileModule : TrackerModule
                 }
                 else
                 {
-                    TrackerBase.Say(_hintTileConfig.ClearHintTileFailed);
+                    TrackerBase.Say(response: _hintTileConfig.ClearHintTileFailed);
                 }
             }
             else
             {
-                TrackerBase.Say(_hintTileConfig.ClearHintTileFailed);
+                TrackerBase.Say(response: _hintTileConfig.ClearHintTileFailed);
             }
         });
     }

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MapModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MapModule.cs
@@ -92,7 +92,7 @@ public class MapModule : TrackerModule
         {
             var mapName = (string)result.Semantics[MapKey].Value;
             TrackerBase.UpdateMap(mapName);
-            TrackerBase.Say(x => x.Map.UpdateMap, mapName);
+            TrackerBase.Say(x => x.Map.UpdateMap, args: [mapName]);
         });
 
         AddCommand("Show dark room map", DarkRoomRule(), (result) =>
@@ -122,7 +122,7 @@ public class MapModule : TrackerModule
                     _prevMap = _config.Maps.Last().ToString();
                 }
                 TrackerBase.UpdateMap(map.ToString());
-                TrackerBase.Say(x => x.Map.ShowDarkRoomMap, map.Name);
+                TrackerBase.Say(x => x.Map.ShowDarkRoomMap, args: [map.Name]);
             }
             else
             {
@@ -139,7 +139,7 @@ public class MapModule : TrackerModule
             else
             {
                 TrackerBase.UpdateMap(_prevMap);
-                TrackerBase.Say(x => x.Map.HideDarkRoomMap, _prevMap);
+                TrackerBase.Say(x => x.Map.HideDarkRoomMap, args: [_prevMap]);
                 _prevMap = "";
             }
         });

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MetaModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MetaModule.cs
@@ -177,21 +177,21 @@ public class MetaModule : TrackerModule
             {
                 case ThresholdSetting_Recognition:
                     TrackerBase.Options.MinimumRecognitionConfidence += adjustment;
-                    TrackerBase.Say(TrackerBase.Responses.TrackerSettingChanged?.Format(
+                    TrackerBase.Say(text: TrackerBase.Responses.TrackerSettingChanged?.Format(
                         "recognition threshold", $"{TrackerBase.Options.MinimumRecognitionConfidence:P0}"));
                     Logger.LogInformation("Temporarily changed recognition threshold to {newValue}", TrackerBase.Options.MinimumRecognitionConfidence);
                     break;
 
                 case ThresholdSetting_Execution:
                     TrackerBase.Options.MinimumExecutionConfidence += adjustment;
-                    TrackerBase.Say(TrackerBase.Responses.TrackerSettingChanged?.Format(
+                    TrackerBase.Say(text: TrackerBase.Responses.TrackerSettingChanged?.Format(
                         "execution threshold", $"{TrackerBase.Options.MinimumExecutionConfidence:P0}"));
                     Logger.LogInformation("Temporarily changed execution threshold to {newValue}", TrackerBase.Options.MinimumExecutionConfidence);
                     break;
 
                 case ThresholdSetting_Sass:
                     TrackerBase.Options.MinimumSassConfidence += adjustment;
-                    TrackerBase.Say(TrackerBase.Responses.TrackerSettingChanged?.Format(
+                    TrackerBase.Say(text: TrackerBase.Responses.TrackerSettingChanged?.Format(
                         "sass threshold", $"{TrackerBase.Options.MinimumSassConfidence:P0}"));
                     Logger.LogInformation("Temporarily changed sass threshold to {newValue}", TrackerBase.Options.MinimumSassConfidence);
                     break;

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MsuModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MsuModule.cs
@@ -138,15 +138,15 @@ public class MsuModule : TrackerModule, IDisposable
         // Respond if we have lines to the song number, song name, or msu name
         if (_msuConfig.SongResponses?.TryGetValue(_currentTrack.MsuName ?? "", out var response) == true)
         {
-            TrackerBase.Say(response);
+            TrackerBase.Say(response: response);
         }
         else if (_msuConfig.SongResponses?.TryGetValue(_currentTrack.SongName, out response) == true)
         {
-            TrackerBase.Say(response);
+            TrackerBase.Say(response: response);
         }
         else if (_msuConfig.SongResponses?.TryGetValue(_currentTrackNumber.ToString(), out response) == true)
         {
-            TrackerBase.Say(response);
+            TrackerBase.Say(response: response);
         }
     }
 
@@ -286,7 +286,7 @@ public class MsuModule : TrackerModule, IDisposable
         {
             if (_currentMsu == null)
             {
-                TrackerBase.Say(_msuConfig.UnknownSong);
+                TrackerBase.Say(response: _msuConfig.UnknownSong);
                 return;
             }
 
@@ -294,11 +294,11 @@ public class MsuModule : TrackerModule, IDisposable
             var track = _currentMsu.GetTrackFor(trackNumber);
             if (track != null)
             {
-                TrackerBase.Say(_msuConfig.CurrentSong, track.GetDisplayText(TrackDisplayFormat.SpeechStyle));
+                TrackerBase.Say(response: _msuConfig.CurrentSong, args: [track.GetDisplayText(TrackDisplayFormat.SpeechStyle)]);
             }
             else
             {
-                TrackerBase.Say(_msuConfig.UnknownSong);
+                TrackerBase.Say(response: _msuConfig.UnknownSong);
             }
         });
 
@@ -306,7 +306,7 @@ public class MsuModule : TrackerModule, IDisposable
         {
             if (_currentMsu == null)
             {
-                TrackerBase.Say(_msuConfig.UnknownSong);
+                TrackerBase.Say(response: _msuConfig.UnknownSong);
                 return;
             }
 
@@ -314,11 +314,11 @@ public class MsuModule : TrackerModule, IDisposable
             var track = _currentMsu.GetTrackFor(trackNumber);
             if (track?.GetMsuName() != null)
             {
-                TrackerBase.Say(_msuConfig.CurrentMsu, track.GetMsuName());
+                TrackerBase.Say(response: _msuConfig.CurrentMsu, args: [track.GetMsuName()]);
             }
             else
             {
-                TrackerBase.Say(_msuConfig.UnknownSong);
+                TrackerBase.Say(response: _msuConfig.UnknownSong);
             }
         });
 
@@ -326,20 +326,20 @@ public class MsuModule : TrackerModule, IDisposable
         {
             if (_currentTrack == null)
             {
-                TrackerBase.Say(_msuConfig.UnknownSong);
+                TrackerBase.Say(response: _msuConfig.UnknownSong);
                 return;
             }
-            TrackerBase.Say(_msuConfig.CurrentSong, _currentTrack.GetDisplayText(TrackDisplayFormat.SpeechStyle));
+            TrackerBase.Say(response: _msuConfig.CurrentSong, args: [_currentTrack.GetDisplayText(TrackDisplayFormat.SpeechStyle)]);
         });
 
         AddCommand("current msu", GetCurrentMsuRules(), (_) =>
         {
             if (_currentTrack == null)
             {
-                TrackerBase.Say(_msuConfig.UnknownSong);
+                TrackerBase.Say(response: _msuConfig.UnknownSong);
                 return;
             }
-            TrackerBase.Say(_msuConfig.CurrentMsu, _currentTrack.GetMsuName());
+            TrackerBase.Say(response: _msuConfig.CurrentMsu, args: [_currentTrack.GetMsuName()]);
         });
     }
 }

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MultiplayerModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/MultiplayerModule.cs
@@ -129,11 +129,11 @@ public class MultiplayerModule : TrackerModule
             _multiplayerGameService.LocalPlayer.HasForfeited) return;
         if (args.DidComplete)
         {
-            TrackerBase.Say(x => x.Multiplayer.OtherPlayerBeatGame, args.PhoneticName);
+            TrackerBase.Say(x => x.Multiplayer.OtherPlayerBeatGame, args: [args.PhoneticName]);
         }
         else if (args.DidForfeit)
         {
-            TrackerBase.Say(x => x.Multiplayer.OtherPlayerForfeitGame, args.PhoneticName);
+            TrackerBase.Say(x => x.Multiplayer.OtherPlayerForfeitGame, args: [args.PhoneticName]);
         }
     }
 
@@ -147,8 +147,8 @@ public class MultiplayerModule : TrackerModule
             return;
         }
 
-        TrackerBase.Say(x => x.Multiplayer.OtherPlayerTrackedItem, args.PhoneticName, item.Metadata.Name,
-            item.Metadata.NameWithArticle);
+        TrackerBase.Say(x => x.Multiplayer.OtherPlayerTrackedItem,
+            args: [args.PhoneticName, item.Metadata.Name, item.Metadata.NameWithArticle]);
     }
 
     private void PlayerTrackedLocation(PlayerTrackedLocationEventHandlerArgs args)
@@ -162,13 +162,13 @@ public class MultiplayerModule : TrackerModule
         _ = TrackerBase.GameService!.TryGiveItemAsync(item, args.PlayerId);
         if (item.Type.IsPossibleProgression(item.World.Config.ZeldaKeysanity, item.World.Config.MetroidKeysanity))
         {
-            TrackerBase.Say(x => x.Multiplayer.ReceivedUsefulItemFromOtherPlayer, args.PhoneticName, item.Metadata.Name,
-                item.Metadata.NameWithArticle);
+            TrackerBase.Say(x => x.Multiplayer.ReceivedUsefulItemFromOtherPlayer,
+                args: [args.PhoneticName, item.Metadata.Name, item.Metadata.NameWithArticle]);
         }
         else if (item.Type.IsInCategory(ItemCategory.Junk))
         {
-            TrackerBase.Say(x => x.Multiplayer.ReceivedJunkItemFromOtherPlayer, args.PhoneticName, item.Metadata.Name,
-                item.Metadata.NameWithArticle);
+            TrackerBase.Say(x => x.Multiplayer.ReceivedJunkItemFromOtherPlayer,
+                args: [args.PhoneticName, item.Metadata.Name, item.Metadata.NameWithArticle]);
         }
         args.LocationState.Cleared = true;
         args.LocationState.Autotracked = true;
@@ -183,14 +183,17 @@ public class MultiplayerModule : TrackerModule
         if (dungeon == null) return;
         if (dungeon is { HasReward: true, DungeonReward: { } })
         {
-            TrackerBase.Say(x => x.Multiplayer.OtherPlayerClearedDungeonWithReward, args.PhoneticName,
-                dungeon.DungeonMetadata.Name, dungeon.DungeonMetadata.Boss, dungeon.DungeonReward.Metadata.Name,
-                dungeon.DungeonReward.Metadata.NameWithArticle);
+            TrackerBase.Say(x => x.Multiplayer.OtherPlayerClearedDungeonWithReward,
+                args: [
+                    args.PhoneticName,
+                    dungeon.DungeonMetadata.Name, dungeon.DungeonMetadata.Boss, dungeon.DungeonReward.Metadata.Name,
+                    dungeon.DungeonReward.Metadata.NameWithArticle
+                ]);
         }
         else
         {
-            TrackerBase.Say(x => x.Multiplayer.OtherPlayerClearedDungeonWithoutReward, args.PhoneticName,
-                dungeon.DungeonMetadata.Name, dungeon.DungeonMetadata.Boss);
+            TrackerBase.Say(x => x.Multiplayer.OtherPlayerClearedDungeonWithoutReward,
+                args: [args.PhoneticName, dungeon.DungeonMetadata.Name, dungeon.DungeonMetadata.Boss]);
         }
     }
 
@@ -200,7 +203,7 @@ public class MultiplayerModule : TrackerModule
         args.BossState.AutoTracked = true;
         var boss = WorldService.World.GoldenBosses.FirstOrDefault(x => x.Type == args.BossState.Type);
         if (boss == null) return;
-        TrackerBase.Say(x => x.Multiplayer.OtherPlayerDefeatedBoss, args.PhoneticName, boss.Metadata.Name);
+        TrackerBase.Say(x => x.Multiplayer.OtherPlayerDefeatedBoss, args: [args.PhoneticName, boss.Metadata.Name]);
     }
 
     private void PlayerTrackedDeath(PlayerTrackedDeathEventHandlerArgs args)
@@ -209,11 +212,11 @@ public class MultiplayerModule : TrackerModule
         {
             Logger.LogInformation("Other player died with death link enabled");
             TrackerBase.GameService!.TryKillPlayer();
-            TrackerBase.Say(x => x.Multiplayer.OtherPlayedDiedDeathLink, args.PhoneticName);
+            TrackerBase.Say(x => x.Multiplayer.OtherPlayedDiedDeathLink, args: [args.PhoneticName]);
         }
         else if(!args.IsLocalPlayer)
         {
-            TrackerBase.Say(x => x.Multiplayer.OtherPlayedDied, args.PhoneticName);
+            TrackerBase.Say(x => x.Multiplayer.OtherPlayedDied, args: [args.PhoneticName]);
         }
 
     }
@@ -246,8 +249,8 @@ public class MultiplayerModule : TrackerModule
         var localItem = ItemService.FirstOrDefault(e.Location.Item.Type);
         if (localItem == null || localItem.State.TrackingState >= e.Location.Item.State.TrackingState) return;
         var otherPlayer = e.Location.Item.World.Config.PhoneticName;
-        TrackerBase.Say(x => x.Multiplayer.GiftedUsefulItemToOtherPlayer, otherPlayer, localItem.Metadata.Name,
-            localItem.Metadata.NameWithArticle);
+        TrackerBase.Say(x => x.Multiplayer.GiftedUsefulItemToOtherPlayer,
+            args: [otherPlayer, localItem.Metadata.Name, localItem.Metadata.NameWithArticle]);
     }
 
     private async void TrackerOnBeatGame(object? sender, TrackerEventArgs e)

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/PersonalityModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/PersonalityModule.cs
@@ -32,7 +32,7 @@ public class PersonalityModule : TrackerModule
     {
         AddCommand("Hey, ya missed pal", GetYaMissedRule(), (_) =>
         {
-            TrackerBase.Say("Here Mike. This will explain everything.", wait: true);
+            TrackerBase.Say(text: "Here Mike. This will explain everything.", wait: true);
             OpenInBrowser(new Uri("https://www.youtube.com/watch?v=5P6UirFDdxM"));
         });
 
@@ -43,7 +43,7 @@ public class PersonalityModule : TrackerModule
 
             AddCommand(request.Phrases.First(), GetRequestRule(request.Phrases), (_) =>
             {
-                TrackerBase.Say(request.Response);
+                TrackerBase.Say(response: request.Response);
             });
         }
     }

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -84,7 +84,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             return;
         }
 
-        TrackerBase.Say(x => x.Hints.AreaSuggestion, result.Value.Location.Region.GetName());
+        TrackerBase.Say(x => x.Hints.AreaSuggestion, args: [result.Value.Location.Region.GetName()]);
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             .ToImmutableList();
         if (locations.Count == 0)
         {
-            TrackerBase.Say(x => x.Hints.AreaAlreadyCleared, area.GetName());
+            TrackerBase.Say(x => x.Hints.AreaAlreadyCleared, args: [area.GetName()]);
             return;
         }
 
@@ -114,7 +114,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                 .Select(x => x.Item)
                 .NonNull();
             var itemNames = NaturalLanguage.Join(items, TrackerBase.World.Config);
-            TrackerBase.Say(x => x.Spoilers.ItemsInArea, area.GetName(), itemNames);
+            TrackerBase.Say(x => x.Spoilers.ItemsInArea, args: [area.GetName(), itemNames]);
         }
         else if (TrackerBase.HintsEnabled)
         {
@@ -141,27 +141,27 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             var usefulness = _gameHintService.GetUsefulness(locations.ToList(), WorldService.Worlds, areaReward);
             if (usefulness == LocationUsefulness.Mandatory)
             {
-                TrackerBase.Say(x => x.Hints.AreaHasSomethingMandatory, area.GetName());
+                TrackerBase.Say(x => x.Hints.AreaHasSomethingMandatory, args: [area.GetName()]);
             }
             else if (usefulness is LocationUsefulness.NiceToHave or LocationUsefulness.Sword)
             {
-                TrackerBase.Say(x => x.Hints.AreaHasSomethingGood, area.GetName());
+                TrackerBase.Say(x => x.Hints.AreaHasSomethingGood, args: [area.GetName()]);
             }
             else if (area is IHasReward region)
             {
                 if (region.RewardType == RewardType.CrystalBlue
                     || region.RewardType == RewardType.CrystalRed)
                 {
-                    TrackerBase.Say(x => x.Hints.AreaHasJunkAndCrystal, area.GetName());
+                    TrackerBase.Say(x => x.Hints.AreaHasJunkAndCrystal, args: [area.GetName()]);
                 }
                 else
                 {
-                    TrackerBase.Say(x => x.Hints.AreaHasJunk, area.GetName());
+                    TrackerBase.Say(x => x.Hints.AreaHasJunk, args: [area.GetName()]);
                 }
             }
             else
             {
-                TrackerBase.Say(x => x.Hints.AreaHasJunk, area.GetName());
+                TrackerBase.Say(x => x.Hints.AreaHasJunk, args: [area.GetName()]);
             }
         }
     }
@@ -174,12 +174,12 @@ public class SpoilerModule : TrackerModule, IOptionalModule
     {
         if (item.Metadata.HasStages && item.State.TrackingState >= item.Metadata.MaxStage)
         {
-            TrackerBase.Say(x => x.Spoilers.TrackedAllItemsAlready, item.Name);
+            TrackerBase.Say(x => x.Spoilers.TrackedAllItemsAlready, args: [item.Name]);
             return;
         }
         else if (!item.Metadata.Multiple && item.State.TrackingState > 0)
         {
-            TrackerBase.Say(x => x.Spoilers.TrackedItemAlready, item.Metadata.NameWithArticle);
+            TrackerBase.Say(x => x.Spoilers.TrackedItemAlready, args: [item.Metadata.NameWithArticle]);
             return;
         }
 
@@ -190,7 +190,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         {
             var locationName = markedLocation.Metadata.Name;
             var regionName = markedLocation.Region.Metadata.Name;
-            TrackerBase.Say(x => x.Spoilers.MarkedItem, item.Metadata.NameWithArticle, locationName, regionName);
+            TrackerBase.Say(x => x.Spoilers.MarkedItem, args: [item.Metadata.NameWithArticle, locationName, regionName]);
             return;
         }
 
@@ -207,15 +207,15 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         if (locations.Count == 0)
         {
             if (item.Metadata.Multiple || item.Metadata.HasStages)
-                TrackerBase.Say(x => x.Spoilers.ItemsNotFound, item.Metadata.Plural);
+                TrackerBase.Say(x => x.Spoilers.ItemsNotFound, args: [item.Metadata.Plural]);
             else
-                TrackerBase.Say(x => x.Spoilers.ItemNotFound, item.Metadata.NameWithArticle);
+                TrackerBase.Say(x => x.Spoilers.ItemNotFound, args: [item.Metadata.NameWithArticle]);
             return;
         }
         else if (locations.Count > 0 && locations.All(x => x.State.Cleared))
         {
             // The item exists, but all locations are cleared
-            TrackerBase.Say(x => x.Spoilers.LocationsCleared, item.Metadata.NameWithArticle);
+            TrackerBase.Say(x => x.Spoilers.LocationsCleared, args: [item.Metadata.NameWithArticle]);
             return;
         }
 
@@ -252,12 +252,12 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             if (TrackerBase.HintsEnabled || TrackerBase.SpoilersEnabled)
             {
                 var itemName = ItemService.GetName(location.Item.Type);
-                TrackerBase.Say(x => x.Hints.LocationAlreadyClearedSpoiler, locationName, itemName);
+                TrackerBase.Say(x => x.Hints.LocationAlreadyClearedSpoiler, args: [locationName, itemName]);
                 return;
             }
             else
             {
-                TrackerBase.Say(x => x.Hints.LocationAlreadyCleared, locationName);
+                TrackerBase.Say(x => x.Hints.LocationAlreadyCleared, args: [locationName]);
                 return;
             }
         }
@@ -267,7 +267,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             var markedItem = ItemService.FirstOrDefault(location.State.MarkedItem.Value);
             if (markedItem != null)
             {
-                TrackerBase.Say(x => x.Spoilers.MarkedLocation, locationName, markedItem.Metadata.NameWithArticle);
+                TrackerBase.Say(x => x.Spoilers.MarkedLocation, args: [locationName, markedItem.Metadata.NameWithArticle]);
                 return;
             }
         }
@@ -306,7 +306,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         Item item, params object?[] additionalArgs)
     {
         var args = Args.Combine(item.Metadata.NameWithArticle, additionalArgs);
-        if (!TrackerBase.Say(responses => selectHint(responses.Hints), args))
+        if (!TrackerBase.Say(responses => selectHint(responses.Hints), args: args))
             return false;
 
         if (_itemHintsGiven.ContainsKey(item.Type))
@@ -332,7 +332,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         Item item, params object?[] additionalArgs)
     {
         var args = Args.Combine(item.Metadata.NameWithArticle, additionalArgs);
-        if (!TrackerBase.Say(hint, args))
+        if (!TrackerBase.Say(response: hint, args: args))
             return false;
 
         if (_itemHintsGiven.ContainsKey(item.Type))
@@ -359,7 +359,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
     {
         var name = location.Metadata.Name;
         var args = Args.Combine(name, additionalArgs);
-        if (!TrackerBase.Say(responses => selectHint(responses.Hints), args))
+        if (!TrackerBase.Say(responses => selectHint(responses.Hints), args: args))
             return false;
 
         if (_locationHintsGiven.ContainsKey(location.Id))
@@ -386,7 +386,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
     {
         var name = location.Metadata.Name;
         var args = Args.Combine(name, additionalArgs);
-        if (!TrackerBase.Say(hint, args))
+        if (!TrackerBase.Say(response: hint, args: args))
             return false;
 
         if (_locationHintsGiven.ContainsKey(location.Id))
@@ -432,7 +432,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         var locationName = location.Metadata.Name;
         if (location.Item.Type == ItemType.Nothing)
         {
-            TrackerBase.Say(x => x.Spoilers.EmptyLocation, locationName);
+            TrackerBase.Say(x => x.Spoilers.EmptyLocation, args: [locationName]);
             return true;
         }
 
@@ -442,20 +442,22 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             if (_isMultiworld)
             {
                 TrackerBase.Say(x => location.Item.World == WorldService.World ? x.Spoilers.LocationHasItemOwnWorld : x.Spoilers.LocationHasItemOtherWorld,
-                    locationName,
-                    item.Metadata.NameWithArticle,
-                    location.Item.World.Player);
+                    args: [
+                        locationName,
+                        item.Metadata.NameWithArticle,
+                        location.Item.World.Player
+                    ]);
             }
             else
             {
-                TrackerBase.Say(x => x.Spoilers.LocationHasItem, locationName, item.Metadata.NameWithArticle);
+                TrackerBase.Say(x => x.Spoilers.LocationHasItem, args: [locationName, item.Metadata.NameWithArticle]);
             }
 
             return true;
         }
         else
         {
-            TrackerBase.Say(x => x.Spoilers.LocationHasUnknownItem, locationName);
+            TrackerBase.Say(x => x.Spoilers.LocationHasUnknownItem, args: [locationName]);
             return true;
         }
     }
@@ -477,26 +479,30 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                 if (item.Metadata.Multiple || item.Metadata.HasStages)
                 {
                     TrackerBase.Say(x => reachableLocation.World == WorldService.World ? x.Spoilers.ItemsAreAtLocationOwnWorld : x.Spoilers.ItemsAreAtLocationOtherWorld,
-                        item.Metadata.NameWithArticle,
-                        locationName,
-                        regionName,
-                        reachableLocation.World.Player);
+                        args: [
+                            item.Metadata.NameWithArticle,
+                            locationName,
+                            regionName,
+                            reachableLocation.World.Player
+                        ]);
                 }
                 else
                 {
                     TrackerBase.Say(x => reachableLocation.World == WorldService.World ? x.Spoilers.ItemIsAtLocationOwnWorld : x.Spoilers.ItemIsAtLocationOtherWorld,
-                        item.Metadata.NameWithArticle,
-                        locationName,
-                        regionName,
-                        reachableLocation.World.Player);
+                        args: [
+                            item.Metadata.NameWithArticle,
+                            locationName,
+                            regionName,
+                            reachableLocation.World.Player
+                        ]);
                 }
             }
             else
             {
                 if (item.Metadata.Multiple || item.Metadata.HasStages)
-                    TrackerBase.Say(x => x.Spoilers.ItemsAreAtLocation, item.Metadata.NameWithArticle, locationName, regionName);
+                    TrackerBase.Say(x => x.Spoilers.ItemsAreAtLocation, args: [item.Metadata.NameWithArticle, locationName, regionName]);
                 else
-                    TrackerBase.Say(x => x.Spoilers.ItemIsAtLocation, item.Metadata.NameWithArticle, locationName, regionName);
+                    TrackerBase.Say(x => x.Spoilers.ItemIsAtLocation, args: [item.Metadata.NameWithArticle, locationName, regionName]);
             }
 
             return true;
@@ -514,26 +520,30 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                 if (item.Metadata.Multiple || item.Metadata.HasStages)
                 {
                     TrackerBase.Say(x => worldLocation.World == WorldService.World ? x.Spoilers.ItemsAreAtOutOfLogicLocationOwnWorld : x.Spoilers.ItemsAreAtOutOfLogicLocationOtherWorld,
-                        item.Metadata.NameWithArticle,
-                        locationName,
-                        regionName,
-                        worldLocation.World.Player);
+                        args: [
+                            item.Metadata.NameWithArticle,
+                            locationName,
+                            regionName,
+                            worldLocation.World.Player
+                        ]);
                 }
                 else
                 {
                     TrackerBase.Say(x => worldLocation.World == WorldService.World ? x.Spoilers.ItemIsAtOutOfLogicLocationOwnWorld : x.Spoilers.ItemIsAtOutOfLogicLocationOtherWorld,
-                        item.Metadata.NameWithArticle,
-                        locationName,
-                        regionName,
-                        worldLocation.World.Player);
+                        args: [
+                            item.Metadata.NameWithArticle,
+                            locationName,
+                            regionName,
+                            worldLocation.World.Player
+                        ]);
                 }
             }
             else
             {
                 if (item.Metadata.Multiple || item.Metadata.HasStages)
-                    TrackerBase.Say(x => x.Spoilers.ItemsAreAtOutOfLogicLocation, item.Metadata.NameWithArticle, locationName, regionName);
+                    TrackerBase.Say(x => x.Spoilers.ItemsAreAtOutOfLogicLocation, args: [item.Metadata.NameWithArticle, locationName, regionName]);
                 else
-                    TrackerBase.Say(x => x.Spoilers.ItemIsAtOutOfLogicLocation, item.Metadata.NameWithArticle, locationName, regionName);
+                    TrackerBase.Say(x => x.Spoilers.ItemIsAtOutOfLogicLocation, args: [item.Metadata.NameWithArticle, locationName, regionName]);
             }
 
             return true;
@@ -704,7 +714,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                         {
                             if (!randomLocationWithHint.World.IsLocalWorld)
                                 TrackerBase.Say(x => x.Hints.ItemInPlayerWorldRegionRoomPrefixHint,
-                                    randomLocationWithHint.World.Config.PhoneticName);
+                                    args: [randomLocationWithHint.World.Config.PhoneticName]);
                             return GiveItemHint(regionHint, item);
                         }
                     }
@@ -732,7 +742,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                             {
                                 if (!randomLocation.World.IsLocalWorld)
                                     TrackerBase.Say(x => x.Hints.ItemInPlayerWorldRegionRoomPrefixHint,
-                                        randomLocation.World.Config.PhoneticName);
+                                        args: [randomLocation.World.Config.PhoneticName]);
                                 return GiveItemHint(roomHint, item);
                             }
                         }
@@ -742,7 +752,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                         {
                             if (!randomLocation.World.IsLocalWorld)
                                 TrackerBase.Say(x => x.Hints.ItemInPlayerWorldRegionRoomPrefixHint,
-                                    randomLocation.World.Config.PhoneticName);
+                                    args: [randomLocation.World.Config.PhoneticName]);
                             return GiveItemHint(locationHint, item);
                         }
                     }
@@ -752,7 +762,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                     {
                         if (!randomLocation.World.IsLocalWorld)
                             TrackerBase.Say(x => x.Hints.ItemInPlayerWorldRegionRoomPrefixHint,
-                                randomLocation.World.Config.PhoneticName);
+                                args: [randomLocation.World.Config.PhoneticName]);
 
                         if (randomLocation.Region is SMRegion
                             && randomLocation.Name.ContainsAny(StringComparison.OrdinalIgnoreCase, s_worthlessLocationNameIndicators))

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/TrackerModule.cs
@@ -357,7 +357,7 @@ public abstract class TrackerModule
                             // If the confidence level is too low to be
                             // executed, but high enough to be recognized,
                             // let Tracker say something
-                            TrackerBase.Say(TrackerBase.Responses.Misheard);
+                            TrackerBase.Say(x => x.Misheard);
                             TrackerBase.RestartIdleTimers();
                         }
                     }


### PR DESCRIPTION
The `selectResponse` parameter is first because that was by far the most common way to call the method. The `selectResponses` parameter is next because there were a few spots that were passing a `SchrodingersString` as the first `args` argument and I needed to prevent that. The `args` argument itself lost its `params` keyword because it rapidly became problematic to distinguish the `args` from the `boolean` `once` and `wait` parameters, since `args` wasn't a `string[]` array.

This would close #497, by way of the `selectResponses` and `tieredKey` parameters.