### PR TITLE
Fix sprite downloads

### DIFF
--- a/src/TrackerCouncil.Smz3.Data/Options/GeneralOptions.cs
+++ b/src/TrackerCouncil.Smz3.Data/Options/GeneralOptions.cs
@@ -218,11 +218,6 @@ public class GeneralOptions : INotifyPropertyChanged
     public List<ConfigSource> ConfigSources { get; set; } = new();
 
     /// <summary>
-    /// Dictionary of previously downloaded hashes
-    /// </summary>
-    public Dictionary<string, string> SpriteHashes { get; set; } = new();
-
-    /// <summary>
     /// Device to be used for push to talk mode
     /// </summary>
     public string PushToTalkDevice { get; set; } = "Default";

--- a/src/TrackerCouncil.Smz3.Data/Services/IGitHubSpriteDownloaderService.cs
+++ b/src/TrackerCouncil.Smz3.Data/Services/IGitHubSpriteDownloaderService.cs
@@ -15,8 +15,9 @@ public interface IGitHubSpriteDownloaderService
     /// <param name="owner">The GitHub repository owner</param>
     /// <param name="repo">The GitHub repository to download</param>
     /// <param name="timeout">How long to timeout from the api call</param>
+    /// <param name="ignoreNoPreviousHashes">If downloads should be triggered, even if no previous hashes exist</param>
     /// <returns>A dictionary of paths on GitHub and their git hashes</returns>
-    public Task<IDictionary<string, string>?> GetSpritesToDownloadAsync(string owner, string repo, TimeSpan? timeout = null);
+    public Task<IDictionary<string, string>?> GetSpritesToDownloadAsync(string owner, string repo, TimeSpan? timeout = null, bool ignoreNoPreviousHashes = false);
 
     /// <summary>
     /// Downloads sprites from GitHub to the folder

--- a/src/TrackerCouncil.Smz3.Data/Services/OptionsWindowService.cs
+++ b/src/TrackerCouncil.Smz3.Data/Services/OptionsWindowService.cs
@@ -192,12 +192,12 @@ public class OptionsWindowService(ConfigProvider configProvider, IMicrophoneServ
 
     private async Task UpdateSpritesAsync()
     {
-        var sprites = await gitHubSpriteDownloaderService.GetSpritesToDownloadAsync("TheTrackerCouncil", "SMZ3CasSprites");
+        var sprites = await gitHubSpriteDownloaderService.GetSpritesToDownloadAsync("TheTrackerCouncil", "SMZ3CasSprites", null, true);
 
         if (sprites?.Any() == true)
         {
             SpriteDownloadStarted?.Invoke(this, EventArgs.Empty);
-            await gitHubSpriteDownloaderService.DownloadSpritesAsync("TheTrackerCouncil", "SMZ3CasSprites");
+            await gitHubSpriteDownloaderService.DownloadSpritesAsync("TheTrackerCouncil", "SMZ3CasSprites", sprites);
             SpriteDownloadEnded?.Invoke(this, EventArgs.Empty);
         }
     }

--- a/src/TrackerCouncil.Smz3.UI/Services/MainWindowService.cs
+++ b/src/TrackerCouncil.Smz3.UI/Services/MainWindowService.cs
@@ -113,14 +113,6 @@ public class MainWindowService(
             return;
         }
 
-        #if DEBUG
-        // Skip sprite download when debugging if the folder already exists
-        if (Directory.Exists(Sprite.SpritePath))
-        {
-            return;
-        }
-        #endif
-
         var toDownload = await gitHubSpriteDownloaderService.GetSpritesToDownloadAsync("TheTrackerCouncil", "SMZ3CasSprites");
 
         if (toDownload is not { Count: > 4 })


### PR DESCRIPTION
I discovered sprite downloads were messed up. Effectively, on a new install it has a list of files included in the build. Previously what would happen is that it would not download any files, then it would save a null value in the yaml config file. Next time it loaded it would fail because it didn't expect a null value.

I also updated it to save the hashes into a new sprite-hashes.yml file so that it would stop making the main randomizer-options.yml file cleaner.