### PR TITLE
Implement tracker reaction images

### DIFF
--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/SchrodingersString.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/SchrodingersString.cs
@@ -101,6 +101,22 @@ public class SchrodingersString : Collection<SchrodingersString.Possibility>, IM
     }
 
     /// <summary>
+    /// Gets the details needed for tracker speaking
+    /// </summary>
+    /// <param name="args"></param>
+    /// <returns>The text for tracker to speak and the image to display, if applicable</returns>
+    public (string SpeechText, string? TrackerImage)? GetSpeechDetails(params object?[] args)
+    {
+        var selectedPossibility = Random(s_random);
+        if (selectedPossibility == null)
+        {
+            return null;
+        }
+        var formattedText = string.Format(selectedPossibility.Text, args);
+        return (formattedText, selectedPossibility.TrackerImage);
+    }
+
+    /// <summary>
     /// Replaces placeholders in the string with the specified values.
     /// </summary>
     /// <param name="args">
@@ -208,6 +224,11 @@ public class SchrodingersString : Collection<SchrodingersString.Possibility>, IM
         /// </summary>
         [DefaultValue(DefaultWeight)]
         public double Weight { get; init; } = DefaultWeight;
+
+        /// <summary>
+        /// The tracker image to display
+        /// </summary>
+        public string? TrackerImage { get; init; } = null;
 
         /// <summary>
         /// Converts the possibility to a string.

--- a/src/TrackerCouncil.Smz3.Tracking/Services/ICommunicator.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/Services/ICommunicator.cs
@@ -9,21 +9,12 @@ namespace TrackerCouncil.Smz3.Tracking.Services;
 public interface ICommunicator
 {
     /// <summary>
-    /// Communicates the specified text to the player.
+    /// Communicates the specified text to the player
     /// </summary>
-    /// <param name="text">
-    /// The plain text or SSML representation of the text to communicate.
+    /// <param name="request">
+    /// The request object containing details about what to communicate
     /// </param>
-    void Say(string text);
-
-    /// <summary>
-    /// Communicates the specified text to the player and blocks the calling
-    /// thread until the text has been fully communicated to the player.
-    /// </summary>
-    /// <param name="text">
-    /// The plain text or SSML representation of the text to communicate.
-    /// </param>
-    void SayWait(string text);
+    void Say(SpeechRequest request);
 
     /// <summary>
     /// If the communicator is currently enabled
@@ -83,7 +74,7 @@ public interface ICommunicator
     /// <summary>
     /// Event for when the communicator has reached a new viseme
     /// </summary>
-    public event EventHandler<VisemeReachedEventArgs> VisemeReached;
+    public event EventHandler<SpeakVisemeReachedEventArgs> VisemeReached;
 
 
 }

--- a/src/TrackerCouncil.Smz3.Tracking/Services/SpeakVisemeReachedEventArgs.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/Services/SpeakVisemeReachedEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Speech.Synthesis;
+
+namespace TrackerCouncil.Smz3.Tracking.Services;
+
+/// <summary>
+/// Event for when tracker says a new line
+/// </summary>
+/// <param name="request">The original speech request</param>
+public class SpeakVisemeReachedEventArgs(VisemeReachedEventArgs visemeDetails, SpeechRequest? request) : EventArgs
+{
+    /// <summary>
+    /// Original viseme details
+    /// </summary>
+    public VisemeReachedEventArgs VisemeDetails => visemeDetails;
+
+    /// <summary>
+    /// The original speech request
+    /// </summary>
+    public SpeechRequest Request => request;
+}

--- a/src/TrackerCouncil.Smz3.Tracking/Services/SpeechRequest.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/Services/SpeechRequest.cs
@@ -1,0 +1,25 @@
+﻿namespace TrackerCouncil.Smz3.Tracking.Services;
+
+/// <summary>
+/// Request that is sent to the ICommunicator
+/// </summary>
+/// <param name="text">The plain text or SSML representation of the text to communicate.</param>
+/// <param name="trackerImage">The tracker image to be displayed</param>
+/// <param name="wait">If the communicator should block the calling thread</param>
+public class SpeechRequest(string text, string? trackerImage = null, bool wait = false)
+{
+    /// <summary>
+    /// The plain text or SSML representation of the text to communicate.
+    /// </summary>
+    public string Text => text;
+
+    /// <summary>
+    /// The tracker image that should be shown
+    /// </summary>
+    public string TrackerImage => trackerImage ?? "default";
+
+    /// <summary>
+    /// If the communicator should block the calling thread
+    /// </summary>
+    public bool Wait => wait;
+}

--- a/src/TrackerCouncil.Smz3.Tracking/Tracker.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/Tracker.cs
@@ -688,6 +688,7 @@ public sealed class Tracker : TrackerBase, IDisposable
         bool wait = false)
     {
         SchrodingersString? selectedResponse = null;
+        string? trackerImage = null;
 
         if (key != null)
         {
@@ -723,24 +724,20 @@ public sealed class Tracker : TrackerBase, IDisposable
             return true;
         }
 
-        var placeholderText = text ?? selectedResponse?.Format(args ?? []);
-
-        if (placeholderText == null)
+        if (text == null)
         {
-            return false;
+            var trackerSpeechDetails = selectedResponse?.GetSpeechDetails(args ?? []);
+            if (trackerSpeechDetails?.SpeechText == null)
+            {
+                return false;
+            }
+            text = trackerSpeechDetails.Value.SpeechText;
+            trackerImage = trackerSpeechDetails.Value.TrackerImage;
         }
 
-        var formattedText = FormatPlaceholders(placeholderText);
+        var formattedText = FormatPlaceholders(text);
 
-        if (wait)
-        {
-            _communicator.SayWait(formattedText);
-        }
-        else
-        {
-            _communicator.Say(formattedText);
-        }
-
+        _communicator.Say(new SpeechRequest(formattedText, trackerImage, wait));
         _lastSpokenText = formattedText;
 
         return true;
@@ -786,7 +783,7 @@ public sealed class Tracker : TrackerBase, IDisposable
             return;
         }
 
-        _communicator.SayWait("I said");
+        _communicator.Say(new SpeechRequest("I said"));
         _communicator.SlowDown();
         Say(text: _lastSpokenText, wait: true);
         _communicator.SpeedUp();

--- a/src/TrackerCouncil.Smz3.UI.Legacy/Windows/MultiplayerConnectWindow.xaml.cs
+++ b/src/TrackerCouncil.Smz3.UI.Legacy/Windows/MultiplayerConnectWindow.xaml.cs
@@ -255,7 +255,8 @@ public sealed partial class MultiplayerConnectWindow : Window, INotifyPropertyCh
 
     private void PhoneticNameTestButton_OnClick(object sender, RoutedEventArgs e)
     {
-        _communicator.Say(string.IsNullOrEmpty(PhoneticName) ? DisplayName : PhoneticName);
+        var nameToSay = string.IsNullOrEmpty(PhoneticName) ? DisplayName : PhoneticName;
+        _communicator.Say(new SpeechRequest(nameToSay));
     }
 
     private void ServerListButton_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
I won't be able to go through any time soon and really find good lines for this, but I'm going ahead and implementing this. This allows you to change the images that are used for tracker. Currently there are three reactions: default, WTF, and bored. Once tracker finishes saying a line, she'll reset back to the default.

It's usable like this in the configs, and the TrackerImage values shouldn't be case sensitive.

```
- Text: <break time='3s'/> Oh I'm sorry. Was I supposed to care about Reserve Tanks?
  Weight: 0.5
  TrackerImage: Bored
```

Apparently I accidentally committed to the config main branch directly. 😬 [Here's the commit for the config branch](https://github.com/TheTrackerCouncil/SMZ3CasConfigs/commit/8f4d5fe3e1b9acc7d7fb7ab1bf413ca5b339b267)