### PR TITLE
Sass when enabling hints/spoilers when already enabled

### DIFF
--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/HintsConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/HintsConfig.cs
@@ -16,6 +16,16 @@ public class HintsConfig : IMergeable<HintsConfig>
     public SchrodingersString? DisabledHints { get; init; }
 
     /// <summary>
+    /// Gets the phrases to respond with when hints are turned on, and the user just said "Enable hints".
+    /// </summary>
+    public SchrodingersString? AlreadyEnabledHints { get; init; }
+
+    /// <summary>
+    /// Gets the phrases to respond with when hints are turned off, and the user just said "Disable hints".
+    /// </summary>
+    public SchrodingersString? AlreadyDisabledHints { get; init; }
+
+    /// <summary>
     /// Gets the phrases to respond with when asked about an item and hints
     /// are turned off.
     /// </summary>

--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/SpoilerConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/SpoilerConfig.cs
@@ -16,6 +16,16 @@ public class SpoilerConfig : IMergeable<SpoilerConfig>
     public SchrodingersString? DisabledSpoilers { get; init; }
 
     /// <summary>
+    /// Gets the phrases to respond with when spoilers are turned on, and the user just said "Enable spoilers".
+    /// </summary>
+    public SchrodingersString? AlreadyEnabledSpoilers { get; init; }
+
+    /// <summary>
+    /// Gets the phrases to respond with when spoilers are turned off, and the user just said "Disable spoilers".
+    /// </summary>
+    public SchrodingersString? AlreadyDisabledSpoilers { get; init; }
+
+    /// <summary>
     /// Gets the phrases to respond with when asked about an item and
     /// spoilers are disabled.
     /// </summary>

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -958,13 +958,27 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         {
             AddCommand("Enable hints", GetEnableHintsRule(), (_) =>
             {
-                TrackerBase.HintsEnabled = true;
-                TrackerBase.Say(x => x.Hints.EnabledHints);
+                if (!TrackerBase.HintsEnabled)
+                {
+                    TrackerBase.HintsEnabled = true;
+                    TrackerBase.Say(x => x.Hints.EnabledHints);
+                }
+                else
+                {
+                    TrackerBase.Say(x => x.Hints.AlreadyEnabledHints);
+                }
             });
             AddCommand("Disable hints", GetDisableHintsRule(), (_) =>
             {
-                TrackerBase.HintsEnabled = false;
-                TrackerBase.Say(x => x.Hints.DisabledHints);
+                if (TrackerBase.HintsEnabled)
+                {
+                    TrackerBase.HintsEnabled = false;
+                    TrackerBase.Say(x => x.Hints.DisabledHints);
+                }
+                else
+                {
+                    TrackerBase.Say(x => x.Hints.AlreadyDisabledHints);
+                }
             });
             AddCommand("Give progression hint", GetProgressionHintRule(), (_) =>
             {
@@ -982,13 +996,27 @@ public class SpoilerModule : TrackerModule, IOptionalModule
         {
             AddCommand("Enable spoilers", GetEnableSpoilersRule(), (_) =>
             {
-                TrackerBase.SpoilersEnabled = true;
-                TrackerBase.Say(x => x.Spoilers.EnabledSpoilers);
+                if (!TrackerBase.SpoilersEnabled)
+                {
+                    TrackerBase.SpoilersEnabled = true;
+                    TrackerBase.Say(x => x.Spoilers.EnabledSpoilers);
+                }
+                else
+                {
+                    TrackerBase.Say(x => x.Spoilers.AlreadyEnabledSpoilers);
+                }
             });
             AddCommand("Disable spoilers", GetDisableSpoilersRule(), (_) =>
             {
-                TrackerBase.SpoilersEnabled = false;
-                TrackerBase.Say(x => x.Spoilers.DisabledSpoilers);
+                if (TrackerBase.SpoilersEnabled)
+                {
+                    TrackerBase.SpoilersEnabled = false;
+                    TrackerBase.Say(x => x.Spoilers.DisabledSpoilers);
+                }
+                else
+                {
+                    TrackerBase.Say(x => x.Spoilers.AlreadyDisabledSpoilers);
+                }
             });
 
             AddCommand("Reveal item location", GetItemSpoilerRule(), (result) =>


### PR DESCRIPTION
I felt like this was missing since I added the hint/spoiler functionality but never actually bothered to change it despite it being such a minor change.