### PR TITLE
Upgrade fixes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET Build + Test + Publish
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, upgrade-fixes ]
   pull_request:
     branches: [ main ]
 
@@ -25,11 +25,22 @@ jobs:
         repository: TheTrackerCouncil/SMZ3CasSprites
         path: sprites
         ref: main
-    - name: Download git tree
+    - name: Download tracker sprite repo
+      uses: actions/checkout@v4
+      with:
+        repository: TheTrackerCouncil/TrackerSprites
+        path: trackersprites
+        ref: main
+    - name: Download sprite git tree
       if: ${{ github.event_name != 'pull_request' }}
       shell: pwsh
       run: |
         Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/SMZ3CasSprites/git/trees/main?recursive=1 -OutFile sprites/Sprites/sprites.json
+    - name: Download tracker sprite git tree
+      if: ${{ github.event_name != 'pull_request' }}
+      shell: pwsh
+      run: |
+        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/TrackerSprites/git/trees/main?recursive=1 -OutFile trackersprites/tracker-sprites.json  
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET Build + Test + Publish
 
 on:
   push:
-    branches: [ main, upgrade-fixes ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,16 +31,18 @@ jobs:
         repository: TheTrackerCouncil/TrackerSprites
         path: trackersprites
         ref: main
-    - name: Download sprite git tree
+    - name: Download git trees
       if: ${{ github.event_name != 'pull_request' }}
       shell: pwsh
+      env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/SMZ3CasSprites/git/trees/main?recursive=1 -OutFile sprites/Sprites/sprites.json
-    - name: Download tracker sprite git tree
-      if: ${{ github.event_name != 'pull_request' }}
-      shell: pwsh
-      run: |
-        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/TrackerSprites/git/trees/main?recursive=1 -OutFile trackersprites/tracker-sprites.json  
+        $headers = @{
+          Authorization="Bearer $Env:GH_TOKEN"
+        }
+        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/SMZ3CasSprites/git/trees/main?recursive=1 -OutFile sprites/Sprites/sprites.json -Headers $headers
+        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/TrackerSprites/git/trees/main?recursive=1 -OutFile trackersprites/tracker-sprites.json -Headers $headers
+        Remove-Item -LiteralPath "trackersprites/.git" -Force -Recurse  
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -108,6 +110,24 @@ jobs:
         repository: TheTrackerCouncil/SMZ3CasSprites
         path: sprites
         ref: main
+    - name: Download tracker sprite repo
+      uses: actions/checkout@v4
+      with:
+        repository: TheTrackerCouncil/TrackerSprites
+        path: trackersprites
+        ref: main
+    - name: Download git trees
+      if: ${{ github.event_name != 'pull_request' }}
+      shell: pwsh
+      env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $headers = @{
+          Authorization="Bearer $Env:GH_TOKEN"
+        }
+        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/SMZ3CasSprites/git/trees/main?recursive=1 -OutFile sprites/Sprites/sprites.json -Headers $headers
+        Invoke-RestMethod -Uri https://api.github.com/repos/TheTrackerCouncil/TrackerSprites/git/trees/main?recursive=1 -OutFile trackersprites/tracker-sprites.json -Headers $headers
+        Remove-Item -LiteralPath "trackersprites/.git" -Force -Recurse
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,3 +1,147 @@
+## Changes in 9.8.0
+
+- **Recreated UI**
+
+  The UI has been completely rewritten from the ground up using a new framework. This new UI framework now sports a dark skin, some efficiency updates which prevents slowdown when resizing the map window, and the ability to have a unified cross platform UI. To work with this new framework, there are some slight changes to behavior as well. For example, when you open tracker, the rom list window will now be hidden until tracker is closed. The Shaktool mode has also now been changed to sport a larger single gif instead of a series of them.
+
+  ![image](https://github.com/TheTrackerCouncil/SMZ3Randomizer/assets/63823784/59f52f2d-4a02-469d-bdcc-c4bdb9ac53fe)
+
+- **Generation Window Updates**
+
+  The generation window has been redesigned into a multi-tab layout. The goal with this change is to have the UI be a little less daunting for newcomers as well as have the primary settings you change each run such as the sprite and MSU to be more easily accessible. Copying config strings from other people has been updated to alter the settings in the window, and you can now see a list of all of the settings at a glance on the main window.
+
+  To go along with this, a new feature has been added: presets for quickly applying logic and patch settings. There are multiple built-in presets which you can select from, and you can even create your own preset by clicking on the down triangle menu button next to the Generate button.
+
+  ![image](https://github.com/TheTrackerCouncil/SMZ3Randomizer/assets/63823784/fe1f00d9-cc05-42bc-9fea-c34a68152b76)
+
+- **MSU Randomizer Updates**
+
+  SMZ3 has been updated to utilize the latest functionality of the MSU Randomizer. You can now adjust the weighting of particular MSUs, and there are different shuffle styles, including options for shuffling jingle tracks or all tracks together.
+
+- **Expanded Linux Version and Mac OS Port**
+
+  As stated before, the new UI framework allows for the Linux version to have a fully functional tracker UI, including the item, location, and map windows. Additionally, for Mac OS X users with the M1 or newer arm processors, there is now a Mac port you can use. However, there is no voice tracking or text to speech for the Linux and Mac ports, so keep that in mind. For instructions on how to setup the Linux and Mac versions, view the [installation section of the main GitHub page](https://github.com/TheTrackerCouncil/SMZ3Randomizer).
+
+- **Miscellaneous Updates and Fixes**
+
+  - The application has been updated to .net 8. For Windows users, it should be automatically installed when updating.
+  - The Specky clip comment will now only be said once per run.
+  - The options window has been slightly re-organized so that the settings are in more appropriate sections.
+  - Fixed an issue where locations being set to "progression" weren't having random items associated with them.
+  - There are now additional Lua connectors which should be compatible with the EmoTracker and Crowd Control. On top that, the Lua scripts have been updated to be more robust. SNI has also been added as a supported connector.
+  - Fixed an issue where the disabled voice detection was broken on Windows.
+  - Fixed an issue where default sprites weren't being announced correctly by tracker.
+  - Fixed an issue where keycard types would be spoiled when viewing them in world.
+  - Fixed an issue where the pre-Crocomire line would be stated in keysanity without the boss keycard.
+  - Bumper cave should now auto track.
+  - The hi jump lobby missile location now requires bombs to access to avoid people accidentally soft locking.
+  - Added a warning when trying to copy a seed number from a randomizer settings string from an old randomizer version that may produce different results.
+  - Fixed an issue where tracker failed to reconnect to chat when she lost the connection to Twitch.
+  - Tracker will now automatically track pegs you hammer on the way to Peg World.
+  - Tracker will also count how many Hyper Beam shots it takes to bring down Mother Brain.
+
+### Changes in 9.8.1
+
+- The previous MSU track should no longer resume after "Samus Fanfare" plays (e.g., after resetting out of Wrecked Pool).
+- MSU tracks should more reliably start over, without fading in, after the packs have been shuffled.
+- The timer in the Tracker window can now be disabled, for when you're using your own timer.
+- Tracker will now combine "Pop"s more often when auto-tracking Peg World.
+- Tracker will now try to combine messages when a lot of items are picked up at once, though she might not be thrilled about it.
+
+### Changes in 9.8.2
+
+- Fixed an issue that caused a crash when opening the MSU Randomizer window.
+
+### Changes in 9.8.3
+
+- Added a button to the top right of the tracker window to resize the window to best fit the current selected layout.
+- Added a progress bar to the sprite download window and made it so the sprite download could be cancelled.
+- Fixed an issue that would cause songs with the name "null" to not work properly with the MSU randomization.
+- Fixed an issue where new sprites wouldn't be downloaded upon first setup of SMZ3.
+- Added a small surprise feature that I'm not sure everyone will be *content* with.
+
+### Changes in 9.8.4
+
+- **Tracker Speech Window**
+
+  Ever want tracker to stare into your soul as she mocks you while playing SMZ3? Well wait no longer! With the new Tracker Speech Window, a tracker image drawn by the talented [DrDubz](https://linktr.ee/mightydubz) will be displayed and be slightly animated when she starts talking. On the tracker window, you can go to View -> Tracker Speech Window to open a window that looks like this:
+
+  ![image](https://github.com/user-attachments/assets/f9d916db-71cf-4f57-afa6-3316bd7189f6)
+
+  For streamers, you should be able capture this window and chroma key it to remove the background and add to your scene:
+
+  https://github.com/user-attachments/assets/f16dbf17-12cd-4720-9652-7d6c790ccf63
+
+  By default, the color you'll need to chroma key is #483D8B, but you can change the color and disable tracker's bounce animation in the settings. You can also right click on the tracker speech window to copy the chroma key hex for using in OBS.
+
+  This feature is pretty new, and will probably be added to in the future, so be on the look out for future updates!
+
+- **Miscellaneous Updates and Fixes**
+
+  - Fixed an issue where new sprites wouldn't download properly and where sometimes all sprites might be redownloaded from GitHub.
+
+### Changes in 9.8.5
+
+- **New Shinespark Cheat**
+
+  Annoyed at missing when getting the Maridia entrance shine spark item? There is now a cheat to enable a shine spark at any time. Just say "Hey tracker, charge a shine spark!" while cheats are enabled. 
+
+- **Tracker Reaction Types**
+
+  Currently no voice lines utilize this, but there is now a functionality to specify the reaction image that tracker will use for voice lines. If anyone wants to add their own voice lines that use this, simply update your voice lines in the config files like this:
+
+  ```
+  - Text: <break time='3s'/> Oh I'm sorry. Was I supposed to care about Reserve Tanks?
+    Weight: 0.5
+    TrackerImage: Bored
+  ```  
+
+  At the moment, the only tracker image types are default, bored, and wtf. Once a voice line is finished, she will automatically switch back to the default images.
+
+- **Miscellaneous Updates and Fixes**
+
+  - When requesting a hint for a single specific location, tracker will now distinguish between mandatory, nice to have, and junk items.
+  - Hint tiles and viewed items now share the same command for triggering them to avoid mix-ups. Basically, saying "Hey tracker, clear that hint tile" or "Hey tracker, clear that marked location" will both work for both hint tiles and marked locations.
+  - Fixed an issue with the tracker responses to specific MSUs and tracks not always working.
+  - Updated the tracker location list to properly scroll again.
+
+### Changes in 9.8.6
+
+- **Keysanity Minimal UI**
+
+  A new UI has been created for the keysanity that is meant to be the same width as the advanced layout so that streamers don't need to change their stream layouts for both.
+   
+  ![image](https://github.com/user-attachments/assets/fa4ee127-883f-4624-aefa-3d53f8e3b7e1)
+
+- **Miscellaneous Updates and Fixes**
+
+  - Fixed an issue where tracker stopped talking after peg world.
+  - Updated hint tiles for keysanity to no longer give hints for crystal dungeons being mandatory to be more in line with regular mode.
+
+### Changes in 9.8.7
+
+- **Hey Tracker, track Halloween**
+
+  There's a bit of a spooky surprise for folks who have tracker's sprite displayed! If anyone doesn't want to use it though, there's an option in the tracker profiles where you can change back.
+
+- **Aga Ledge/Lumberjack Tree is Actually in Logic Now**
+
+  Due to an issue going back _years_ now at this point, Aga ledge was never actually possible to have progression generated on them. This has now been resolved. Note that with this change, there's a possibility that using seeds from other people from before this version may not generate the same.
+
+- **Miscellaneous Updates and Fixes**
+
+  - Fixed an issue where push-to-talk mode wasn't working.
+  - Fixed an issue with plando files not loading properly.
+  - Fixed an issue where the banner to disable update notifications wasn't taking while the settings menu option was.
+  - Added additional commands for the shine spark cheat.
+
+### Changes in 9.8.8
+
+- **Miscellaneous Updates and Fixes**
+
+  - Removed weighting for Aga ledge, making it very slightly less likely to have progression (around 7% instead of 7.5%)
+  - Changed the default tracker back to the original one. For anyone who would like to continue using the Halloween tracker sprites, you can select them in your tracker profiles in the settings.
+
 ## Changes in 9.7.0
 
 - **Push-to-talk**

--- a/setup/LinuxBuildZipper.ps1
+++ b/setup/LinuxBuildZipper.ps1
@@ -25,6 +25,12 @@ if (Test-Path -LiteralPath "$folder\Sprites") {
 }
 Copy-Item "$parentFolder\sprites\Sprites\" -Destination "$folder\Sprites" -Recurse
 
+# Copy tracker sprites to be bundled together
+if (Test-Path -LiteralPath "$folder\TrackerSprites") {
+    Remove-Item -LiteralPath "$folder\TrackerSprites" -Recurse
+}
+Copy-Item "$parentFolder\trackersprites\" -Destination "$folder\TrackerSprites" -Recurse
+
 # Copy configs to be bundled together
 if (Test-Path -LiteralPath "$folder\Configs") {
     Remove-Item -LiteralPath "$folder\Configs" -Recurse

--- a/setup/package-macos-app.sh
+++ b/setup/package-macos-app.sh
@@ -25,6 +25,7 @@ cp -a "$PUBLISH_OUTPUT_DIRECTORY/." "$APP_NAME/Contents/MacOS"
 
 # Bundle sprites and configs
 cp -r "sprites/Sprites" "$APP_NAME/Contents/MacOS/Sprites"
+cp -r "trackersprites" "$APP_NAME/Contents/MacOS/TrackerSprites"
 cp -r "configs/Profiles" "$APP_NAME/Contents/MacOS/Configs"
 
 echo "Packaged $APP_NAME successfully."

--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -48,11 +48,14 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [InstallDelete]
 Type: filesandordirs; Name: "{app}\Sprites"
+Type: filesandordirs; Name: "{app}\TrackerSprites"
 
 [Files]
 Source: "netcorecheck.exe"; Flags: dontcopy noencryption
 Source: "netcorecheck_x64.exe"; Flags: dontcopy noencryption
 Source: "..\sprites\Sprites\*"; DestDir: "{app}\Sprites"; Excludes: "\bin\*,obj\*,*.cs,*.csproj"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+Source: "..\trackersprites\*"; DestDir: "{app}\TrackerSprites"; Excludes: "\bin\*,obj\*,*.cs,*.csproj"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\src\TrackerCouncil.Smz3.UI\bin\Release\net8.0\win-x64\publish\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion; Check: Is64BitInstallMode;
 Source: "..\src\TrackerCouncil.Smz3.UI\bin\Release\net8.0\win-x64\publish\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Check: Is64BitInstallMode;
 Source: "..\src\TrackerCouncil.Smz3.UI\bin\Release\net8.0\win-x86\publish\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion; Check: "not Is64BitInstallMode";

--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
@@ -18,6 +18,12 @@ public class AutoTrackerConfig : IMergeable<AutoTrackerConfig>
     public SchrodingersString? WhenDisconnected { get; init; }
 
     /// <summary>
+    /// Gets the phrases to respond when the Auto Tracker has been stuck in a connect/disconnect loop and has
+    /// given up on trying to connect.
+    /// </summary>
+    public SchrodingersString? WhenDisconnectLimitReached { get; init; }
+
+    /// <summary>
     /// Gets the phrases to respond with when the game is started.
     /// </summary>
     public SchrodingersString? GameStarted { get; init; }

--- a/src/TrackerCouncil.Smz3.Data/RandomizerDirectories.cs
+++ b/src/TrackerCouncil.Smz3.Data/RandomizerDirectories.cs
@@ -104,5 +104,5 @@ public static class RandomizerDirectories
     public static string TrackerSpriteHashYamlFilePath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "tracker-sprite-hashes.yml");
 #endif
 
-    public static string TrackerSpriteInitialJsonFilePath => Path.Combine(SpritePath, "tracker-sprites.json");
+    public static string TrackerSpriteInitialJsonFilePath => Path.Combine(TrackerSpritePath, "tracker-sprites.json");
 }

--- a/src/TrackerCouncil.Smz3.Data/Tracking/AutoTrackerMetroidState.cs
+++ b/src/TrackerCouncil.Smz3.Data/Tracking/AutoTrackerMetroidState.cs
@@ -108,9 +108,7 @@ public class AutoTrackerMetroidState
     /// Checks to make sure that the state is valid and fully loaded. There's a period upon first booting up that
     /// all of these are 0s, but some of the memory in the location data can be screwy.
     /// </summary>
-    public bool IsValid => Energy is > 0 and < 1999 && ReserveTanks is >= 0 and < 600 && (CurrentRoom != 0 ||
-        CurrentRegion != 0 || CurrentRoomInRegion != 0 || Energy != 0 ||
-        SamusX != 0 || SamusY != 0);
+    public bool IsValid => CurrentRoom != 0 || CurrentRegion != 0 || CurrentRoomInRegion != 0;
 
     /// <summary>
     /// Prints debug data for the state

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTracker.cs
@@ -30,7 +30,6 @@ public class AutoTracker : AutoTrackerBase
     private ISnesConnectorService _snesConnectorService;
     private bool _isEnabled;
     private int _numDisconnects;
-    private bool _connectionValidated;
     private CancellationTokenSource? _validationCts;
 
     /// <summary>

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTrackerModules/GameMonitor.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/AutoTrackerModules/GameMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,8 @@ namespace TrackerCouncil.Smz3.Tracking.AutoTracking.AutoTrackerModules;
 public class GameMonitor(TrackerBase tracker, ISnesConnectorService snesConnector, ILogger<GameMonitor> logger, IWorldQueryService worldQueryService) : AutoTrackerModule(tracker, snesConnector, logger)
 {
     private bool bIsCheckingGameStart;
+
+    private bool bIsFirstStart = true;
 
     public override void Initialize()
     {
@@ -142,19 +145,24 @@ public class GameMonitor(TrackerBase tracker, ISnesConnectorService snesConnecto
 
         AutoTracker.HasStarted = true;
 
-        if (Tracker.World.Config.RomGenerator != RomGenerator.Cas)
+        if (bIsFirstStart)
         {
-            Tracker.Say(x => x.AutoTracker.GameStartedNonCas);
-        }
-        else if (Tracker.World.Config.MultiWorld && worldQueryService.Worlds.Count > 1)
-        {
-            var worldCount = worldQueryService.Worlds.Count;
-            var otherPlayerName = worldQueryService.Worlds.Where(x => x != worldQueryService.World).Random(new Random())!.Config.PhoneticName;
-            Tracker.Say(x => x.AutoTracker.GameStartedMultiplayer, args: [worldCount, otherPlayerName]);
-        }
-        else
-        {
-            Tracker.Say(x => x.AutoTracker.GameStarted, args: [Tracker.Rom?.Seed]);
+            if (Tracker.World.Config.RomGenerator != RomGenerator.Cas)
+            {
+                Tracker.Say(x => x.AutoTracker.GameStartedNonCas);
+            }
+            else if (Tracker.World.Config.MultiWorld && worldQueryService.Worlds.Count > 1)
+            {
+                var worldCount = worldQueryService.Worlds.Count;
+                var otherPlayerName = worldQueryService.Worlds.Where(x => x != worldQueryService.World).Random(new Random())!.Config.PhoneticName;
+                Tracker.Say(x => x.AutoTracker.GameStartedMultiplayer, args: [worldCount, otherPlayerName]);
+            }
+            else
+            {
+                Tracker.Say(x => x.AutoTracker.GameStarted, args: [Tracker.Rom?.Seed]);
+            }
+
+            bIsFirstStart = false;
         }
     }
 

--- a/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
+++ b/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
@@ -6,7 +6,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <Version>9.9.0-beta.1</Version>
+        <Version>9.9.0-rc.1</Version>
         <AssemblyName>SMZ3CasRandomizer</AssemblyName>
         <ApplicationIcon>Assets\smz3.ico</ApplicationIcon>
         <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>

--- a/src/TrackerCouncil.Smz3.UI/Views/SetupWindow.axaml
+++ b/src/TrackerCouncil.Smz3.UI/Views/SetupWindow.axaml
@@ -213,7 +213,7 @@
               Or, if you're ready to get started, you can open the window to start generating your first randomizer seed!
             </TextBlock>
 
-            <Button Margin="0 10" HorizontalAlignment="Left" Click="CloseAndOpenGenerateWindowButton_OnClick">Close Setup and Generation Window</Button>
+            <Button Margin="0 10" HorizontalAlignment="Left" Click="CloseAndOpenGenerateWindowButton_OnClick">Close Setup and Open Generate Custom Game Window</Button>
 
           </StackPanel>
 


### PR DESCRIPTION
- Updated version to RC 1
- Adds tracker sprites to packaged versions
- Fix sprite syncing when the folder doesn't already exist
- Force a full detection of if the player is playing the game on a disconnect. This should hopefully help limit issues that could arise when switching games when doing something like a multi game randomizer using Archipelago like Pink did a while back
- Wait a couple seconds after connecting to the emulator verify that the connection is solid, then stop trying to connect if it detects it's in a disconnect/reconnect loop. This is way more reliable than it used to be, so anymore the situation only seems to arise when the either the connecting application (usually SNI) craps out or if the player is in a different game like Super Metroid. (Fixes #252). Tracker will state a message telling the player to check the application used to connect and make sure the correct rom is playing.