### PR TITLE
Fixes for 9.9.0 release

### DIFF
--- a/src/TrackerCouncil.Smz3.Abstractions/ITrackerBossService.cs
+++ b/src/TrackerCouncil.Smz3.Abstractions/ITrackerBossService.cs
@@ -17,8 +17,8 @@ public interface ITrackerBossService
     /// <param name="admittedGuilt">
     /// <see langword="true"/> if the command implies the boss was killed;
     /// <see langword="false"/> if the boss was simply "tracked".
-    /// <param name="force">If the boss should be forced to be tracked while auto tracking</param>
     /// </param>
+    /// <param name="force">If the boss should be forced to be tracked while auto tracking</param>
     public void MarkBossAsDefeated(IHasBoss region, float? confidence = null, bool autoTracked = false, bool admittedGuilt = false, bool force = false);
 
     /// <summary>

--- a/src/TrackerCouncil.Smz3.Data/TrackerCouncil.Smz3.Data.csproj
+++ b/src/TrackerCouncil.Smz3.Data/TrackerCouncil.Smz3.Data.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.11" />
-    <PackageReference Include="MattEqualsCoder.DynamicForms.Core" Version="1.0.1" />
+    <PackageReference Include="MattEqualsCoder.DynamicForms.Core" Version="1.0.2" />
     <PackageReference Include="MattEqualsCoder.GitHubReleaseChecker" Version="1.1.2" />
     <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="3.0.1" />
     <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />

--- a/src/TrackerCouncil.Smz3.Data/ViewModels/OptionsWindowTwitchIntegration.cs
+++ b/src/TrackerCouncil.Smz3.Data/ViewModels/OptionsWindowTwitchIntegration.cs
@@ -62,7 +62,7 @@ public class OptionsWindowTwitchIntegration : INotifyPropertyChanged
     [DynamicFormFieldCheckBox("Enable poll creation", order: 60)]
     public bool EnablePollCreation { get; set; }
 
-    [DynamicFormFieldNumericUpDown(minValue: 0, label: "Chat response time limit (in minutes):", groupName: "Bottom", order: 70)]
+    [DynamicFormFieldNumericUpDown(minValue: 0, label: "Chat greeting time period (in minutes):", groupName: "Bottom", order: 70, toolTipText: "How long before tracker will stop responding to messages from chat greeting her.")]
     public int ChatGreetingTimeLimit { get; set; }
 
     [DynamicFormFieldComboBox(label: "GT guessing game style:", order: 80)]

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/IHasReward.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/IHasReward.cs
@@ -49,6 +49,10 @@ public interface IHasReward
         Reward = region.World.Rewards.First(x => x.Type == rewardType && x.Region == null);
         Reward.Region = this;
         RewardState.RewardType = rewardType;
+        if (rewardType.IsInCategory(RewardCategory.NonRandomized))
+        {
+            RewardState.MarkedReward = RewardType;
+        }
     }
 
     public RewardType MarkedReward

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Region.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Region.cs
@@ -83,9 +83,9 @@ public abstract class Region : IHasLocations
     public ILogic Logic => World.Logic;
 
     /// <summary>
-    /// Gets the list of region-specific items, e.g. keys, maps, compasses.
+    /// Gets the map of generic items to region-specific items, e.g. keys, maps, compasses
     /// </summary>
-    protected IList<ItemType> RegionItems { get; init; } = new List<ItemType>();
+    protected IDictionary<ItemType, ItemType> RegionItems { get; init; } = new Dictionary<ItemType, ItemType>();
 
     /// <summary>
     /// Name of the map to display when in this region
@@ -102,7 +102,17 @@ public abstract class Region : IHasLocations
     /// </returns>
     public bool IsRegionItem(Item item)
     {
-        return RegionItems.Contains(item.Type);
+        return RegionItems.Values.Contains(item.Type);
+    }
+
+    /// <summary>
+    /// Takes a generic item (e.g. key, compass, etc.) and returns the regional specific version of it if found
+    /// </summary>
+    /// <param name="originalType">The generic item that is desired to be replaced</param>
+    /// <returns>The regional version of the item, if found. Returns the originalType passed in if not found.</returns>
+    public ItemType ConvertToRegionItemType(ItemType originalType)
+    {
+        return RegionItems.TryGetValue(originalType, out var itemType) ? itemType : originalType;
     }
 
     /// <summary>

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/CastleTower.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/CastleTower.cs
@@ -14,7 +14,10 @@ public class CastleTower : Z3Region, IHasReward, IHasTreasure, IHasBoss
     public CastleTower(World world, Config config, IMetadataService? metadata, TrackerState? trackerState)
         : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyCT];
+        RegionItems = new Dictionary<ItemType, ItemType>()
+        {
+            { ItemType.Key, ItemType.KeyCT }
+        };
 
         Foyer = new FoyerRoom(this, metadata, trackerState);
         DarkMaze = new DarkMazeRoom(this, metadata, trackerState);

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/DesertPalace.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/DesertPalace.cs
@@ -14,7 +14,13 @@ public class DesertPalace : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public DesertPalace(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyDP, ItemType.BigKeyDP, ItemType.MapDP, ItemType.CompassDP];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyDP },
+            { ItemType.BigKey, ItemType.BigKeyDP },
+            { ItemType.Map, ItemType.MapDP },
+            { ItemType.Compass, ItemType.CompassDP },
+        };
 
         BigChest = new Location(this, LocationId.DesertPalaceBigChest, 0x1E98F, LocationType.Regular,
             name: "Big Chest",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/EasternPalace.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/EasternPalace.cs
@@ -14,7 +14,12 @@ public class EasternPalace : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public EasternPalace(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.BigKeyEP, ItemType.MapEP, ItemType.CompassEP];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.BigKey, ItemType.BigKeyEP },
+            { ItemType.Map, ItemType.MapEP },
+            { ItemType.Compass, ItemType.CompassEP },
+        };
 
         CannonballChest = new Location(this, LocationId.EasternPalaceCannonballChest, 0x1E9B3, LocationType.Regular,
             name: "Cannonball Chest",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/GanonsTower.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/GanonsTower.cs
@@ -14,7 +14,13 @@ public class GanonsTower : Z3Region, IHasTreasure, IHasBoss
 {
     public GanonsTower(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyGT, ItemType.BigKeyGT, ItemType.MapGT, ItemType.CompassGT];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyGT },
+            { ItemType.BigKey, ItemType.BigKeyGT },
+            { ItemType.Map, ItemType.MapGT },
+            { ItemType.Compass, ItemType.CompassGT },
+        };
 
         BobsTorch = new Location(this, LocationId.GanonsTowerBobsTorch, 0x308161, LocationType.Regular,
             name: "Bob's Torch",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/HyruleCastle.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/HyruleCastle.cs
@@ -16,7 +16,11 @@ public class HyruleCastle : Z3Region, IHasTreasure, IHasBoss
 
     public HyruleCastle(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyHC, ItemType.MapHC];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyHC },
+            { ItemType.Map, ItemType.MapHC },
+        };
 
         Sanctuary = new Location(this, LocationId.Sanctuary, 0x1EA79, LocationType.Regular,
                 name: "Sanctuary",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/IcePalace.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/IcePalace.cs
@@ -14,7 +14,13 @@ public class IcePalace : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public IcePalace(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyIP, ItemType.BigKeyIP, ItemType.MapIP, ItemType.CompassIP];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyIP },
+            { ItemType.BigKey, ItemType.BigKeyIP },
+            { ItemType.Map, ItemType.MapIP },
+            { ItemType.Compass, ItemType.CompassIP },
+        };
 
         CompassChest = new Location(this, LocationId.IcePalaceCompassChest, 0x1E9D4, LocationType.Regular,
             name: "Compass Chest",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/MiseryMire.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/MiseryMire.cs
@@ -14,7 +14,13 @@ public class MiseryMire : Z3Region, IHasReward, IHasPrerequisite, IHasTreasure, 
 {
     public MiseryMire(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyMM, ItemType.BigKeyMM, ItemType.MapMM, ItemType.CompassMM];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyMM },
+            { ItemType.BigKey, ItemType.BigKeyMM },
+            { ItemType.Map, ItemType.MapMM },
+            { ItemType.Compass, ItemType.CompassMM },
+        };
 
         MainLobby = new Location(this, LocationId.MiseryMireMainLobby, 0x1EA5E, LocationType.Regular,
             name: "Main Lobby",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/PalaceOfDarkness.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/PalaceOfDarkness.cs
@@ -14,7 +14,13 @@ public class PalaceOfDarkness : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public PalaceOfDarkness(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyPD, ItemType.BigKeyPD, ItemType.MapPD, ItemType.CompassPD];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyPD },
+            { ItemType.BigKey, ItemType.BigKeyPD },
+            { ItemType.Map, ItemType.MapPD },
+            { ItemType.Compass, ItemType.CompassPD },
+        };
 
         ShooterRoom = new Location(this, LocationId.PalaceOfDarknessShooterRoom, 0x1EA5B, LocationType.Regular,
             name: "Shooter Room",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/SkullWoods.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/SkullWoods.cs
@@ -14,7 +14,13 @@ public class SkullWoods : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public SkullWoods(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeySW, ItemType.BigKeySW, ItemType.MapSW, ItemType.CompassSW];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeySW },
+            { ItemType.BigKey, ItemType.BigKeySW },
+            { ItemType.Map, ItemType.MapSW },
+            { ItemType.Compass, ItemType.CompassSW },
+        };
 
         PotPrison = new Location(this, LocationId.SkullWoodsPotPrison, 0x1E9A1, LocationType.Regular,
             name: "Pot Prison",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/SwampPalace.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/SwampPalace.cs
@@ -14,7 +14,13 @@ public class SwampPalace : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public SwampPalace(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeySP, ItemType.BigKeySP, ItemType.MapSP, ItemType.CompassSP];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeySP },
+            { ItemType.BigKey, ItemType.BigKeySP },
+            { ItemType.Map, ItemType.MapSP },
+            { ItemType.Compass, ItemType.CompassSP },
+        };
 
         Entrance = new Location(this, LocationId.SwampPalaceEntrance, 0x1EA9D, LocationType.Regular,
                 name: "Entrance",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/ThievesTown.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/ThievesTown.cs
@@ -14,7 +14,13 @@ public class ThievesTown : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public ThievesTown(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyTT, ItemType.BigKeyTT, ItemType.MapTT, ItemType.CompassTT];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyTT },
+            { ItemType.BigKey, ItemType.BigKeyTT },
+            { ItemType.Map, ItemType.MapTT },
+            { ItemType.Compass, ItemType.CompassTT },
+        };
 
         MapChest = new Location(this, LocationId.ThievesTownMapChest, 0x1EA01, LocationType.Regular,
             name: "Map Chest",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/TowerOfHera.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/TowerOfHera.cs
@@ -14,7 +14,13 @@ public class TowerOfHera : Z3Region, IHasReward, IHasTreasure, IHasBoss
 {
     public TowerOfHera(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyTH, ItemType.BigKeyTH, ItemType.MapTH, ItemType.CompassTH];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyTH },
+            { ItemType.BigKey, ItemType.BigKeyTH },
+            { ItemType.Map, ItemType.MapTH },
+            { ItemType.Compass, ItemType.CompassTH },
+        };
 
         BasementCage = new Location(this, LocationId.TowerOfHeraBasementCage, 0x308162, LocationType.HeraStandingKey,
             name: "Basement Cage",

--- a/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/TurtleRock.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/Regions/Zelda/TurtleRock.cs
@@ -14,7 +14,13 @@ public class TurtleRock : Z3Region, IHasReward, IHasPrerequisite, IHasTreasure, 
 {
     public TurtleRock(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
     {
-        RegionItems = [ItemType.KeyTR, ItemType.BigKeyTR, ItemType.MapTR, ItemType.CompassTR];
+        RegionItems = new Dictionary<ItemType, ItemType>
+        {
+            { ItemType.Key, ItemType.KeyTR },
+            { ItemType.BigKey, ItemType.BigKeyTR },
+            { ItemType.Map, ItemType.MapTR },
+            { ItemType.Compass, ItemType.CompassTR },
+        };
 
         CompassChest = new Location(this, LocationId.TurtleRockCompassChest, 0x1EA22, LocationType.Regular,
             name: "Compass Chest",

--- a/src/TrackerCouncil.Smz3.LegacyLogic/LegacyWorld.cs
+++ b/src/TrackerCouncil.Smz3.LegacyLogic/LegacyWorld.cs
@@ -126,7 +126,7 @@ namespace Randomizer.SMZ3 {
         }
 
         void SetRewards(IEnumerable<LegacyRewardType> rewards) {
-            var regions = Regions.OfType<ILegacyReward>().Where(x => x.LegacyReward == None);
+            var regions = Regions.OfType<ILegacyReward>().Where(x => x.LegacyReward != Agahnim);
             foreach (var (region, reward) in regions.Zip(rewards)) {
                 region.LegacyReward = reward;
             }

--- a/src/TrackerCouncil.Smz3.SeedGenerator/FileData/Patches/LocationsPatch.cs
+++ b/src/TrackerCouncil.Smz3.SeedGenerator/FileData/Patches/LocationsPatch.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using TrackerCouncil.Smz3.Data.ParsedRom;
@@ -212,6 +211,11 @@ public class LocationsPatch : RomPatch
             isProgression = true;
         }
 
+        if (itemType is ItemType.Key or ItemType.BigKey or ItemType.Compass or ItemType.Map)
+        {
+            var originalItemType = itemType;
+            itemType = location.Region.ConvertToRegionItemType(originalItemType);
+        }
 
         return new ParsedRomLocationDetails()
         {

--- a/src/TrackerCouncil.Smz3.Shared/Multiplayer/MultiplayerVersion.cs
+++ b/src/TrackerCouncil.Smz3.Shared/Multiplayer/MultiplayerVersion.cs
@@ -2,5 +2,5 @@
 
 public static class MultiplayerVersion
 {
-    public const int Id = 5;
+    public const int Id = 6;
 }

--- a/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/ViewedText.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/AutoTracking/ZeldaStateChecks/ViewedText.cs
@@ -103,7 +103,7 @@ public class ViewedText : IZeldaStateCheck
     private void MarkRedCrystalDungeons()
     {
         var dungeons = World.RewardRegions.Where(x =>
-            x is { RewardType: RewardType.PendantGreen, HasCorrectlyMarkedReward: false }).ToList();
+            x is { RewardType: RewardType.CrystalRed, HasCorrectlyMarkedReward: false }).ToList();
 
         if (dungeons.Count == 0)
         {

--- a/src/TrackerCouncil.Smz3.Tracking/TrackingServices/TrackerLocationService.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/TrackingServices/TrackerLocationService.cs
@@ -77,7 +77,7 @@ internal class TrackerLocationService(ILogger<TrackerTreasureService> logger, IP
             var isKeysanityForLocation = (location.Region is Z3Region && World.Config.ZeldaKeysanity) || (location.Region is SMRegion && World.Config.MetroidKeysanity);
             var items = playerProgressionService.GetProgression(!isKeysanityForLocation);
 
-            if (previousAccessibility is not (Accessibility.Available or Accessibility.AvailableWithKeys) && (confidence >= Options.MinimumSassConfidence || autoTracked))
+            if (previousAccessibility is Accessibility.OutOfLogic && (confidence >= Options.MinimumSassConfidence || autoTracked))
             {
                 var locationInfo = location.Metadata;
                 var roomInfo = location.Room?.Metadata;

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/BossTrackingModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/BossTrackingModule.cs
@@ -149,11 +149,11 @@ public class BossTrackingModule : TrackerModule
                 if (contentItemData != null)
                 {
                     TrackerBase.Say(x => x.DungeonBossClearedAddContent);
-                    TrackerBase.ItemTracker.TrackItem(contentItemData);
+                    TrackerBase.ItemTracker.TrackItem(contentItemData, force: true);
                 }
 
                 // Track boss with associated dungeon
-                TrackerBase.BossTracker.MarkBossAsDefeated(dungeon, result.Confidence);
+                TrackerBase.BossTracker.MarkBossAsDefeated(dungeon, result.Confidence, force: true);
                 return;
             }
 
@@ -163,13 +163,13 @@ public class BossTrackingModule : TrackerModule
                 if (contentItemData != null)
                 {
                     TrackerBase.Say(x => x.DungeonBossClearedAddContent);
-                    TrackerBase.ItemTracker.TrackItem(contentItemData);
+                    TrackerBase.ItemTracker.TrackItem(contentItemData, force: true);
                 }
 
                 // Track standalone boss
                 var admittedGuilt = result.Text.ContainsAny("killed", "beat", "defeated", "dead")
                                     && !result.Text.ContainsAny("beat off", "beaten off");
-                TrackerBase.BossTracker.MarkBossAsDefeated(boss, admittedGuilt, result.Confidence);
+                TrackerBase.BossTracker.MarkBossAsDefeated(boss, admittedGuilt, result.Confidence, force: true);
                 return;
             }
 

--- a/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
+++ b/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
@@ -20,7 +20,7 @@
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia_Gif" Version="1.0.0" />
         <PackageReference Include="MattEqualsCoder.AvaloniaControls" Version="1.4.3" />
-        <PackageReference Include="MattEqualsCoder.DynamicForms.Avalonia" Version="1.0.1" />
+        <PackageReference Include="MattEqualsCoder.DynamicForms.Avalonia" Version="1.0.2" />
         <PackageReference Include="MattEqualsCoder.MSURandomizer.Avalonia" Version="3.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
         <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
+++ b/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
@@ -6,7 +6,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <Version>9.9.0-rc.3</Version>
+        <Version>9.9.0</Version>
         <AssemblyName>SMZ3CasRandomizer</AssemblyName>
         <ApplicationIcon>Assets\smz3.ico</ApplicationIcon>
         <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>

--- a/src/TrackerCouncil.Smz3.UI/ViewModels/TrackerWindowDungeonPanelViewModel.cs
+++ b/src/TrackerCouncil.Smz3.UI/ViewModels/TrackerWindowDungeonPanelViewModel.cs
@@ -74,7 +74,7 @@ public class TrackerWindowDungeonPanelViewModel : TrackerWindowPanelViewModel
             menuItems.Add(menuItem);
         }
 
-        if (RewardRegion != null)
+        if (RewardRegion != null && RewardRegion?.RewardType.IsInCategory(RewardCategory.NonRandomized) != true)
         {
             AddRewardMenuItem(menuItems, RewardType.PendantGreen);
             AddRewardMenuItem(menuItems, RewardType.PendantRed);
@@ -84,7 +84,7 @@ public class TrackerWindowDungeonPanelViewModel : TrackerWindowPanelViewModel
         }
 
         // For parsed AP/Mainline roms, show the Metroid boss rewards
-        if (Region?.World.Config.RomGenerator != RomGenerator.Cas)
+        if (Region?.World.Config.RomGenerator != RomGenerator.Cas && RewardRegion?.RewardType.IsInCategory(RewardCategory.NonRandomized) != true)
         {
             AddRewardMenuItem(menuItems, RewardType.KraidToken);
             AddRewardMenuItem(menuItems, RewardType.PhantoonToken);


### PR DESCRIPTION
- Fix #644 where SMZ3 would crash on refresh profiles
- Fix issue with dungeon items not being tracked in parsed roms
- Updated auto tracking to clear locations even if item tracking fails (happens with cheats and AP seeds with starting items)
- Updated Pyramid Fairy showing logic incorrectly in AP seeds
- Fix issue where Aga was not being marked by default
- Fix issue where tracker would say the whole line about needing the player to say please when marking as defeated without damage
- Updated verbiage for the chat greeting time limit
- Fix #635 where viewing the bomb merchant would not mark the red crystals
- Fix issue with some locations being stated to be out of logic (hopefully)