### PR TITLE
Fix reloading when there are no remaining locations

### DIFF
--- a/src/TrackerCouncil.Smz3.UI/Services/TrackerLocationsWindowService.cs
+++ b/src/TrackerCouncil.Smz3.UI/Services/TrackerLocationsWindowService.cs
@@ -157,8 +157,12 @@ public class TrackerLocationsWindowService(TrackerBase trackerBase, IWorldQueryS
 
         _allRegions = regionModels;
         ShowSortedRegions();
-        _lastRegion = _model.Regions.First();
-        _lastRegion.SortOrder = 1;
+
+        if (_model.Regions.Any())
+        {
+            _lastRegion = _model.Regions.First();
+            _lastRegion.SortOrder = 1;
+        }
     }
 
     private void ShowSortedRegions()

--- a/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
+++ b/src/TrackerCouncil.Smz3.UI/TrackerCouncil.Smz3.UI.csproj
@@ -6,7 +6,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <Version>9.9.3</Version>
+        <Version>9.9.4</Version>
         <AssemblyName>SMZ3CasRandomizer</AssemblyName>
         <ApplicationIcon>Assets\smz3.ico</ApplicationIcon>
         <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>


### PR DESCRIPTION
I know we've had lots of small releases lately, but I'm going to create a build for this as I think this will probably hit Pink when she gets back to SMZ3 in her AP async. I think it is likely to hit other people playing SMZ3 in the async AP going on right now.