### PR TITLE
Fix AP required medallion tracking

### DIFF
--- a/src/TrackerCouncil.Smz3.Data/WorldData/World.cs
+++ b/src/TrackerCouncil.Smz3.Data/WorldData/World.cs
@@ -330,12 +330,15 @@ public class World
             return;
         }
 
+        var hasAllMedallions = trackerState?.ItemStates.Count(x =>
+            x.Type is ItemType.Quake or ItemType.Ether or ItemType.Bombos && x.TrackingState > 0) == 3;
+
         var worldState = new LegacyWorldState()
         {
             Medallions =
             [
-                GetLegacyMedallion(MiseryMire),
-                GetLegacyMedallion(TurtleRock)
+                GetLegacyMedallion(MiseryMire, hasAllMedallions),
+                GetLegacyMedallion(TurtleRock, hasAllMedallions)
             ],
             Rewards =
             [
@@ -380,19 +383,16 @@ public class World
         };
     }
 
-    private LegacyWorldState.LegacyMedallion GetLegacyMedallion(IHasPrerequisite region)
+    private LegacyWorldState.LegacyMedallion GetLegacyMedallion(IHasPrerequisite region, bool hasAllMedallions)
     {
-        var unobtainedMedallion = AllItems.FirstOrDefault(x =>
-            x.IsLocalPlayerItem && x.Type.IsInCategory(ItemCategory.Medallion) && x.TrackingState == 0)?.Type;
-
-        var requiredItemType =
-            region.MarkedItem ?? unobtainedMedallion ?? region.RequiredItem;
+        var requiredItemType = hasAllMedallions ? region.RequiredItem : region.MarkedItem ?? ItemType.Nothing;
 
         return requiredItemType switch
         {
             ItemType.Bombos => LegacyWorldState.LegacyMedallion.Bombos,
             ItemType.Ether => LegacyWorldState.LegacyMedallion.Ether,
-            _ => LegacyWorldState.LegacyMedallion.Bombos
+            ItemType.Quake => LegacyWorldState.LegacyMedallion.Quake,
+            _ => LegacyWorldState.LegacyMedallion.Unknown
         };
     }
 

--- a/src/TrackerCouncil.Smz3.LegacyLogic/LegacyWorldState.cs
+++ b/src/TrackerCouncil.Smz3.LegacyLogic/LegacyWorldState.cs
@@ -8,6 +8,7 @@ namespace Randomizer.SMZ3 {
     public class LegacyWorldState {
 
         public enum LegacyMedallion {
+            Unknown,
             Bombos,
             Ether,
             Quake,

--- a/src/TrackerCouncil.Smz3.LegacyLogic/Regions/Zelda/LegacyMiseryMire.cs
+++ b/src/TrackerCouncil.Smz3.LegacyLogic/Regions/Zelda/LegacyMiseryMire.cs
@@ -37,6 +37,11 @@ namespace Randomizer.SMZ3.Regions.Zelda {
 
         // Need "CanKillManyEnemies" if implementing swordless
         public override bool CanEnter(LegacyProgression items) {
+            if (LegacyMedallion == LegacyMedallion.Unknown && (!items.Bombos || !items.Ether || !items.Quake))
+            {
+                return false;
+            }
+
             return LegacyMedallion switch {
                     LegacyMedallion.Bombos => items.Bombos,
                     LegacyMedallion.Ether => items.Ether,

--- a/src/TrackerCouncil.Smz3.LegacyLogic/Regions/Zelda/LegacyTurtleRock.cs
+++ b/src/TrackerCouncil.Smz3.LegacyLogic/Regions/Zelda/LegacyTurtleRock.cs
@@ -51,6 +51,11 @@ namespace Randomizer.SMZ3.Regions.Zelda {
         }
 
         public override bool CanEnter(LegacyProgression items) {
+            if (LegacyMedallion == LegacyMedallion.Unknown && (!items.Bombos || !items.Ether || !items.Quake))
+            {
+                return false;
+            }
+
             return LegacyMedallion switch {
                     LegacyMedallion.Bombos => items.Bombos,
                     LegacyMedallion.Ether => items.Ether,

--- a/src/TrackerCouncil.Smz3.Tracking/TrackingServices/TrackerPrerequisiteService.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/TrackingServices/TrackerPrerequisiteService.cs
@@ -38,6 +38,8 @@ internal class TrackerPrerequisiteService(IPlayerProgressionService playerProgre
             Tracker.Say(response: Responses.DungeonRequirementMarked, args: [medallion.ToString(), region.Metadata.Name]);
         }
 
+        World.UpdateLegacyWorld(World.State);
+
         UpdateAccessibility(region);
 
         AddUndo(autoTracked, () =>


### PR DESCRIPTION
This fixes an issue where MM/TR would sometimes appear as in logic when they shouldn't be.