### PR TITLE
Various Fixes and Updates

### DIFF
--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigFiles/GameLinesConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigFiles/GameLinesConfig.cs
@@ -38,6 +38,11 @@ public class GameLinesConfig : IMergeable<GameLinesConfig>, IConfigFile<GameLine
     public SchrodingersString? HintLocationIsMandatory { get; init; }
 
     /// <summary>
+    /// Hints for stating that a location has a dungeon key or keycard
+    /// </summary>
+    public SchrodingersString? HintLocationHasKey { get; init; }
+
+    /// <summary>
     /// Hints for stating that a location has an item that is useful, but not
     /// mandatory for completing the game
     /// </summary>

--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigFiles/HintTileConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigFiles/HintTileConfig.cs
@@ -43,6 +43,11 @@ public class HintTileConfig : IMergeable<HintTileConfig>, IConfigFile<HintTileCo
     public SchrodingersString? ViewedHintTileMandatory { get; set; }
 
     /// <summary>
+    /// The response for viewing a hint tile for a place that has a key or a keycard
+    /// </summary>
+    public SchrodingersString? ViewedHintTileKey { get; set; }
+
+    /// <summary>
     /// The response for viewing a hint tile for a place that's useless
     /// </summary>
     public SchrodingersString? ViewedHintTileUseless { get; set; }

--- a/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/HintsConfig.cs
+++ b/src/TrackerCouncil.Smz3.Data/Configuration/ConfigTypes/HintsConfig.cs
@@ -195,6 +195,13 @@ public class HintsConfig : IMergeable<HintsConfig>
     public SchrodingersString? LocationHasMandatoryItem { get; init; }
 
     /// <summary>
+    /// Gets the hints for locations that have a key or keycard
+    /// <c>{0}</c> is placeholder for the name of the location.
+    /// <c>{1}</c> is placeholder for the name of the character who the item is for.
+    /// </summary>
+    public SchrodingersString? LocationHasKey { get; init; }
+
+    /// <summary>
     /// Gets the hints for locations that might have something useful.
     /// <c>{0}</c> is placeholder for the name of the location.
     /// <c>{1}</c> is placeholder for the name of the character who the item is for.
@@ -255,6 +262,13 @@ public class HintsConfig : IMergeable<HintsConfig>
     /// <c>{0}</c> is a placeholder for the name of the area.
     /// </summary>
     public SchrodingersString? AreaHasSomethingMandatory { get; init; }
+
+    /// <summary>
+    /// Gets the hint to give for an area that has one or more useful
+    /// keys or keycards.
+    /// <c>{0}</c> is a placeholder for the name of the area.
+    /// </summary>
+    public SchrodingersString? AreaHasKey { get; init; }
 
     /// <summary>
     /// Gets the hint to give for an area that might have one or more useful

--- a/src/TrackerCouncil.Smz3.Data/Services/IMetadataService.cs
+++ b/src/TrackerCouncil.Smz3.Data/Services/IMetadataService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using TrackerCouncil.Smz3.Data.Configuration.ConfigFiles;
 using TrackerCouncil.Smz3.Data.Configuration.ConfigTypes;
+using TrackerCouncil.Smz3.Data.Options;
 using TrackerCouncil.Smz3.Data.WorldData;
 using TrackerCouncil.Smz3.Data.WorldData.Regions;
 using TrackerCouncil.Smz3.Shared.Enums;
@@ -83,6 +84,16 @@ public interface IMetadataService
     /// The current selected mood
     /// </summary>
     public string Mood { get; }
+
+    /// <summary>
+    /// If an alternate tracker sprite pack was picked
+    /// </summary>
+    public bool IsAltTrackerPack { get; }
+
+    /// <summary>
+    /// The selected tracker sprite pack, if applicable
+    /// </summary>
+    public TrackerSpeechImagePack? TrackerSpeechImagePack { get; }
 
     /// <summary>
     /// The selected tracker sprite profile config, if applicable

--- a/src/TrackerCouncil.Smz3.Data/Services/MetadataService.cs
+++ b/src/TrackerCouncil.Smz3.Data/Services/MetadataService.cs
@@ -63,7 +63,9 @@ internal class MetadataService : IMetadataService
 
     public string Mood { get; private set; } = null!;
 
-    public TrackerProfileConfig? TrackerSpriteProfile { get; private set; } = null!;
+    public bool IsAltTrackerPack { get; private set; }
+    public TrackerSpeechImagePack? TrackerSpeechImagePack { get; private set; }
+    public TrackerProfileConfig? TrackerSpriteProfile { get; private set; }
 
     public void ReloadConfigs()
     {
@@ -72,9 +74,18 @@ internal class MetadataService : IMetadataService
         var trackerPack = options.GeneralOptions.TrackerSpeechImagePack;
         if (string.IsNullOrEmpty(trackerPack))
         {
-            trackerPack = "default";
+            trackerPack = "Default";
         }
-        TrackerSpriteProfile = _trackerSpriteService.GetPack(trackerPack)?.ProfileConfig;
+
+        IsAltTrackerPack = false;
+        if (trackerPack == "Default" && new Random().NextDouble() <= .01)
+        {
+            IsAltTrackerPack = true;
+            trackerPack = "Mr Smooth";
+        }
+
+        TrackerSpeechImagePack = _trackerSpriteService.GetPack(trackerPack) ?? _trackerSpriteService.GetPack("Default");
+        TrackerSpriteProfile = TrackerSpeechImagePack?.ProfileConfig;
 
         var profiles = options.GeneralOptions.SelectedProfiles.NonNull().ToImmutableList();
         Mood = _configProvider.GetAvailableMoods(profiles.NonNull().ToImmutableList()).Random(Random.Shared) ?? "";

--- a/src/TrackerCouncil.Smz3.SeedGenerator/Infrastructure/PlaythroughService.cs
+++ b/src/TrackerCouncil.Smz3.SeedGenerator/Infrastructure/PlaythroughService.cs
@@ -67,18 +67,18 @@ public class PlaythroughService
     /// Returns a list of all of the spheres for a given set of locations
     /// </summary>
     /// <param name="allLocations">List of locations to iterate through</param>
-    /// <param name="defaultRewards"></param>
     /// <param name="defaultReward"></param>
+    /// <param name="defaultItems"></param>
     /// <returns>A list of the spheres</returns>
     /// <exception cref="RandomizerGenerationException">When not all locations are </exception>
-    public IEnumerable<Playthrough.Sphere> GenerateSpheres(IEnumerable<Location> allLocations, Reward? defaultReward = null)
+    public IEnumerable<Playthrough.Sphere> GenerateSpheres(IEnumerable<Location> allLocations, Reward? defaultReward = null, List<Item>? defaultItems = null)
     {
         var allLocationsList = allLocations.ToList();
         var worlds = allLocationsList.Select(x => x.Region.World).Distinct().ToList();
 
         var spheres = new List<Playthrough.Sphere>();
         var locations = new List<Location>();
-        var items = new List<Item>();
+        var items = defaultItems ?? [];
         var defaultRewards = new List<Reward>();
         if (defaultReward != null)
         {

--- a/src/TrackerCouncil.Smz3.Shared/Enums/LocationUsefulness.cs
+++ b/src/TrackerCouncil.Smz3.Shared/Enums/LocationUsefulness.cs
@@ -5,5 +5,6 @@ public enum LocationUsefulness
     Useless,
     NiceToHave,
     Sword,
-    Mandatory
+    Mandatory,
+    Key
 }

--- a/src/TrackerCouncil.Smz3.Tracking/Tracker.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/Tracker.cs
@@ -50,6 +50,7 @@ public sealed class Tracker : TrackerBase, IDisposable
 
     private bool _disposed;
     private string? _lastSpokenText;
+    private bool _isAltMode;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -97,6 +98,7 @@ public sealed class Tracker : TrackerBase, IDisposable
         _communicator = communicator;
         _stateService = stateService;
         _timerService = timerService;
+        _isAltMode = metadata.IsAltTrackerPack;
 
         // Initialize the tracker configuration
         _communicator.UseAlternateVoice(metadata.TrackerSpriteProfile?.UseAltVoice ?? false);
@@ -313,7 +315,15 @@ public sealed class Tracker : TrackerBase, IDisposable
             loadError = true;
         }
 
-        Say(response: Responses.StartedTracking);
+        if (_isAltMode)
+        {
+            Say(response: Responses.StartingTrackingAlternate);
+        }
+        else
+        {
+            Say(response: Responses.StartedTracking);
+        }
+
         RestartIdleTimers();
         return !loadError;
     }

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/ChatIntegrationModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/ChatIntegrationModule.cs
@@ -519,6 +519,7 @@ public class ChatIntegrationModule : TrackerModule, IDisposable
             if (waitingOnReconnect)
             {
                 TrackerBase.Say(x => x.Chat.WhenDisconnected);
+                waitingOnReconnect = false;
             }
         }
         catch (Exception ex)

--- a/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/TrackerCouncil.Smz3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -82,7 +82,7 @@ public class SpoilerModule : TrackerModule, IOptionalModule
 
         var result = _gameHintService.FindMostValueableLocation(WorldQueryService.Worlds, locations);
 
-        if (result is not { Usefulness: LocationUsefulness.Mandatory })
+        if (result is not { Usefulness: LocationUsefulness.Mandatory or LocationUsefulness.Key})
         {
             TrackerBase.Say(x => x.Hints.NoApplicableHints);
             return;
@@ -149,6 +149,10 @@ public class SpoilerModule : TrackerModule, IOptionalModule
             if (usefulness == LocationUsefulness.Mandatory)
             {
                 TrackerBase.Say(x => x.Hints.AreaHasSomethingMandatory, args: [area.GetName()]);
+            }
+            else if (usefulness == LocationUsefulness.Key)
+            {
+                TrackerBase.Say(x => x.Hints.AreaHasKey, args: [area.GetName()]);
             }
             else if (usefulness is LocationUsefulness.NiceToHave or LocationUsefulness.Sword)
             {
@@ -479,6 +483,8 @@ public class SpoilerModule : TrackerModule, IOptionalModule
                 {
                     case LocationUsefulness.Mandatory:
                         return GiveLocationHint(x => x.LocationHasMandatoryItem, location, characterName);
+                    case LocationUsefulness.Key:
+                        return GiveLocationHint(x => x.LocationHasKey, location, characterName);
                     case LocationUsefulness.NiceToHave or LocationUsefulness.Sword:
                         return GiveLocationHint(x => x.LocationHasUsefulItem, location, characterName);
                     default:

--- a/src/TrackerCouncil.Smz3.UI/Services/OptionsWindowService.cs
+++ b/src/TrackerCouncil.Smz3.UI/Services/OptionsWindowService.cs
@@ -95,6 +95,11 @@ public class OptionsWindowService(
         return _model;
     }
 
+    public void Close()
+    {
+        communicator.Dispose();
+    }
+
     public void SaveViewModel()
     {
         var options = optionsFactory.Create();

--- a/src/TrackerCouncil.Smz3.UI/Services/TrackerSpeechWindowService.cs
+++ b/src/TrackerCouncil.Smz3.UI/Services/TrackerSpeechWindowService.cs
@@ -10,7 +10,7 @@ using TrackerCouncil.Smz3.UI.ViewModels;
 
 namespace TrackerCouncil.Smz3.UI.Services;
 
-public class TrackerSpeechWindowService(ICommunicator communicator, OptionsFactory optionsFactory, TrackerSpriteService trackerSpriteService) : ControlService
+public class TrackerSpeechWindowService(ICommunicator communicator, OptionsFactory optionsFactory, IMetadataService metadataService) : ControlService
 {
     TrackerSpeechWindowViewModel _model = new();
 
@@ -30,7 +30,7 @@ public class TrackerSpeechWindowService(ICommunicator communicator, OptionsFacto
 
     public TrackerSpeechWindowViewModel GetViewModel()
     {
-        _trackerSpeechImagePack = trackerSpriteService.GetPack();
+        _trackerSpeechImagePack = metadataService.TrackerSpeechImagePack;
 
         if (_trackerSpeechImagePack == null)
         {

--- a/src/TrackerCouncil.Smz3.UI/Views/OptionsWindow.axaml
+++ b/src/TrackerCouncil.Smz3.UI/Views/OptionsWindow.axaml
@@ -12,6 +12,7 @@
         Width="600"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
+        Closing="Window_OnClosing"
         Icon="/Assets/smz3.ico"
         x:DataType="viewModels:OptionsWindowViewModel">
   <LayoutTransformControl x:Name="MainLayout">

--- a/src/TrackerCouncil.Smz3.UI/Views/OptionsWindow.axaml.cs
+++ b/src/TrackerCouncil.Smz3.UI/Views/OptionsWindow.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Avalonia.Interactivity;
 using AvaloniaControls.Controls;
 using AvaloniaControls.Models;
@@ -62,6 +63,11 @@ public partial class OptionsWindow : ScalableWindow
         _service?.SaveViewModel();
         GlobalScaleFactor = _model.RandomizerOptions.UIScaleFactor;
         Close();
+    }
+
+    private void Window_OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        _service?.Close();
     }
 }
 

--- a/src/TrackerCouncil.Smz3.UI/Views/SetupWindow.axaml.cs
+++ b/src/TrackerCouncil.Smz3.UI/Views/SetupWindow.axaml.cs
@@ -112,13 +112,14 @@ public partial class SetupWindow : Window
 
     private void NextButton_OnClick(object? sender, RoutedEventArgs e)
     {
+        _service?.SaveSettings();
+
         if (_model.StepNumber < 4)
         {
             _model.StepNumber++;
         }
         else
         {
-            _service?.SaveSettings();
             Close();
         }
     }


### PR DESCRIPTION
Fixes #696 - Hints for where items aren't will now refer to the area with the most accessible uncleared locations.
Fixes #695 - This will pull in the new region hints that should avoid potentially misleading hints.
Fixes #694 - When disconnected from Twitch, Tracker will check to see if you've reconnected after 15 seconds before mentioning being disconnected.
Fixes #689 - When playing keysanity, mandatory locations with keys or keycards are double checked to see if it's only the key/keycard that is mandatory so that it will provide alternative text.
Fixes #687 - Adds back a random chance of Mr. Smooth being used if the "Default" profile is being used.
Fixes #685 - The initial setup window now saves upon each click of the next button, so if people close with the x button it'll preserve what they set.