### PR TITLE
Update custom sprites to be categorized

### DIFF
--- a/src/TrackerCouncil.Smz3.Data/Options/Sprite.cs
+++ b/src/TrackerCouncil.Smz3.Data/Options/Sprite.cs
@@ -78,6 +78,11 @@ public class Sprite : IEquatable<Sprite>
 
     public bool IsUserSprite { get; set; }
 
+    public static string GetFolderName(SpriteType type)
+    {
+        return s_folderNames[type];
+    }
+
     public bool MatchesFilter(string searchTerm, SpriteFilter spriteFilter) => (string.IsNullOrEmpty(searchTerm) ||
                                                                                    Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
                                                                                    Author.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) &&


### PR DESCRIPTION
I noticed during testing that the custom sprite copying didn't work as expected because apparently I made it so custom sprites weren't added to subdirectories for each sprite type. Updated custom sprites to be categorized into Link/Samus/Ships subfolders like the default sprites and fixed the sprite initialization to actually copy over the user's old custom sprites.